### PR TITLE
Mejoras en Tilemap y correcciones de UI

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -481,6 +481,8 @@ body {
     justify-content: space-between;
     align-items: center;
     flex-shrink: 0;
+    position: relative;
+    z-index: 20; /* Ensure header is above content overlays */
 }
 
 .close-panel-btn {
@@ -2134,17 +2136,17 @@ body {
 
 #animation-panel-overlay {
     position: absolute;
-    top: 45px; /* Below the header */
+    top: 35px; /* Below the header */
     left: 0;
     width: 100%;
-    height: calc(100% - 45px);
+    height: calc(100% - 35px);
     background-color: rgba(0,0,0,0.7);
     display: flex;
     justify-content: center;
     align-items: center;
     color: var(--text-secondary);
     font-size: 1.2em;
-    z-index: 1600; /* Above other content, below header */
+    z-index: 10;
 }
 
 #animation-panel-overlay.hidden {
@@ -2931,16 +2933,33 @@ body {
 
 #palette-panel-overlay {
     position: absolute;
-    top: 0;
+    top: 35px;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: calc(100% - 35px);
     background: rgba(0, 0, 0, 0.5);
     display: flex;
     justify-content: center;
     align-items: center;
     color: white;
     z-index: 10;
+}
+
+.panel-overlay-message {
+    position: absolute;
+    top: 35px;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 35px);
+    background-color: rgba(0,0,0,0.6);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+    text-align: center;
+    padding: 20px;
+    box-sizing: border-box;
 }
 
 #code-editor-toolbar {

--- a/editor.html
+++ b/editor.html
@@ -388,6 +388,7 @@ public star() {
                                     <button id="tool-pan" class="toolbar-btn" title="Panear (W)">↔️ Panear</button>
                                     <hr class="tilemap-tool-divider" style="display: none;">
                                     <button id="tool-tile-brush" class="toolbar-btn tilemap-tool" title="Pincel de Tiles (B)" style="display: none;">🖌️ Pincel</button>
+                                    <button id="tool-tile-bucket" class="toolbar-btn tilemap-tool" title="Relleno de Tiles" style="display: none;">🪣 Relleno</button>
                                     <button id="tool-tile-eraser" class="toolbar-btn tilemap-tool" title="Goma de Tiles (N)" style="display: none;">🧼 Goma</button>
                                 </div>
                             </div>
@@ -1391,7 +1392,8 @@ public star() {
                     </div>
                     <div class="tool-bubble">
                         <button id="palette-tool-brush" class="tool-btn active" data-tool="tile-brush" title="Pincel de Tiles">🖌️</button>
-                        <button id="palette-tool-rect" class="tool-btn" data-tool="tile-rectangle-fill" title="Relleno Rectangular">🖼️</button>
+                        <button id="palette-tool-rect" class="tool-btn" data-tool="tile-rectangle-fill" title="Selección Rectangular">🖼️</button>
+                        <button id="palette-tool-bucket" class="tool-btn" data-tool="tile-bucket" title="Relleno (Bucket)">🪣</button>
                         <button id="palette-tool-eraser" class="tool-btn" data-tool="tile-eraser" title="Goma de Tiles">🧼</button>
                         <button id="palette-edit-btn" class="tool-btn" data-tool="organize" title="Modo Organizar">✏️</button>
                     </div>

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -180,7 +180,7 @@ let getSelectedTile;
 let setPaletteActiveTool = null;
 
 // Module State
-let activeTool = 'move'; // 'move', 'rotate', 'scale', 'pan', 'tile-brush', 'tile-eraser', 'terrain-brush'
+let activeTool = 'move'; // 'move', 'rotate', 'scale', 'pan', 'tile-brush', 'tile-bucket', 'tile-eraser', 'terrain-brush'
 let isAddingLayer = false;
 let isDragging = false;
 let lastSelectedId = -1;
@@ -1093,7 +1093,7 @@ export function initialize(dependencies) {
         }
 
         // --- Tile Painting Logic (Left-click) ---
-        if (e.button === 0 && (activeTool === 'tile-brush' || activeTool === 'tile-eraser')) {
+        if (e.button === 0 && (activeTool === 'tile-brush' || activeTool === 'tile-bucket' || activeTool === 'tile-eraser')) {
             e.stopPropagation();
             paintTile(e); // Paint on the first click
 
@@ -1222,7 +1222,7 @@ export function update() {
         });
 
         // If the selected object is not a tilemap, switch back to a default tool
-        if (!hasTilemap && (activeTool === 'tile-brush' || activeTool === 'tile-eraser')) {
+        if (!hasTilemap && (activeTool === 'tile-brush' || activeTool === 'tile-bucket' || activeTool === 'tile-eraser')) {
             setActiveTool('move');
         }
 
@@ -1311,7 +1311,7 @@ function drawCameraGizmos(renderer) {
 }
 
 function drawTileCursor() {
-    if (activeTool !== 'tile-brush' && activeTool !== 'tile-eraser') return;
+    if (activeTool !== 'tile-brush' && activeTool !== 'tile-bucket' && activeTool !== 'tile-eraser') return;
 
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
@@ -1336,6 +1336,8 @@ function drawTileCursor() {
 
     const layerWidth = width * cellSize.x;
     const layerHeight = height * cellSize.y;
+
+    let toolPerformedAction = false;
 
     for (const layer of tilemap.layers) {
         const layerOffsetX = layer.position.x * layerWidth;
@@ -1920,6 +1922,53 @@ function drawTilemapColliders() {
     ctx.restore();
 }
 
+function isSameTile(tileA, tileB) {
+    if (!tileA && !tileB) return true;
+    if (!tileA || !tileB) return false;
+    // For comparison, we use spriteName and imageData.
+    // If it's an animated tile, we might need more checks later.
+    return tileA.spriteName === tileB.spriteName && tileA.imageData === tileB.imageData;
+}
+
+function floodFill(tilemap, layer, startCol, startRow, newTile) {
+    const key = `${startCol},${startRow}`;
+    const targetTile = layer.tileData.get(key);
+
+    if (isSameTile(targetTile, newTile)) return false;
+
+    const stack = [[startCol, startRow]];
+    const width = tilemap.width;
+    const height = tilemap.height;
+    const visited = new Set();
+
+    let count = 0;
+    while (stack.length > 0) {
+        const [c, r] = stack.pop();
+        const k = `${c},${r}`;
+
+        if (c < 0 || c >= width || r < 0 || r >= height) continue;
+        if (visited.has(k)) continue;
+
+        const currentTile = layer.tileData.get(k);
+        if (isSameTile(currentTile, targetTile)) {
+            layer.tileData.set(k, {
+                spriteName: newTile.spriteName,
+                imageData: newTile.imageData,
+                type: newTile.type || 'sprite',
+                animationPath: newTile.animationPath || null
+            });
+            visited.add(k);
+            count++;
+
+            stack.push([c + 1, r]);
+            stack.push([c - 1, r]);
+            stack.push([c, r + 1]);
+            stack.push([c, r - 1]);
+        }
+    }
+    return count > 0;
+}
+
 function paintTile(event) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) {
@@ -1973,35 +2022,74 @@ function paintTile(event) {
         const row = Math.floor(mouseInLayerY / cellSize.y);
 
         if (col >= 0 && col < width && row >= 0 && row < height) {
-            if (col === lastPaintedCoords.col && row === lastPaintedCoords.row) return;
+            if (col === lastPaintedCoords.col && row === lastPaintedCoords.row) {
+                // If erasing, we still want to continue to other layers if we haven't returned yet
+                if (activeTool === 'tile-eraser') continue;
+                else return;
+            }
 
             const key = `${col},${row}`;
-            if (activeTool === 'tile-brush') {
+            if (activeTool === 'tile-brush' || activeTool === 'tile-rectangle-fill') {
+                const tilesToPaint = getSelectedTile();
+                if (tilesToPaint && tilesToPaint.length > 0) {
+                    for (const tileObject of tilesToPaint) {
+                        const targetCol = col + (tileObject.offsetX || 0);
+                        const targetRow = row + (tileObject.offsetY || 0);
+
+                        // Check bounds
+                        if (targetCol >= 0 && targetCol < width && targetRow >= 0 && targetRow < height) {
+                            layer.tileData.set(`${targetCol},${targetRow}`, {
+                                spriteName: tileObject.spriteName,
+                                imageData: tileObject.imageData,
+                                type: tileObject.type || 'sprite',
+                                animationPath: tileObject.animationPath || null
+                            });
+                        }
+                    }
+
+                    VerificationSystem.updateStatus(tilesToPaint[0], true, "¡Pattern Pintado!", `Coordenadas: [${col}, ${row}]\nTiles: ${tilesToPaint.length}`);
+                    toolPerformedAction = true;
+                    lastPaintedCoords = { col, row };
+                    break; // Paint on one layer at a time (usually the first one that matches)
+                } else {
+                    VerificationSystem.updateStatus(null, false, "Error: No hay ningún tile seleccionado en la paleta.");
+                    return;
+                }
+            } else if (activeTool === 'tile-bucket') {
                 const tilesToPaint = getSelectedTile();
                 if (tilesToPaint && tilesToPaint.length > 0) {
                     const tileObject = tilesToPaint[0];
-                    layer.tileData.set(key, tileObject);
-                    VerificationSystem.updateStatus(tileObject, true, "¡Tile Pintado!", `Coordenadas: [${col}, ${row}]\nDatos: ${tileObject.spriteName}`);
+                    if (floodFill(tilemap, layer, col, row, tileObject)) {
+                        toolPerformedAction = true;
+                        VerificationSystem.updateStatus(tileObject, true, "Relleno Completado", `Capa: ${i}`);
+                    }
+                    break; // Fill one layer at a time
                 } else {
                     VerificationSystem.updateStatus(null, false, "Error: No hay ningún tile seleccionado en la paleta.");
                     return;
                 }
             } else if (activeTool === 'tile-eraser') {
-                layer.tileData.delete(key);
-                VerificationSystem.updateStatus(null, true, "Tile Borrado", `Coordenadas: [${col}, ${row}]`);
+                if (layer.tileData.has(key)) {
+                    layer.tileData.delete(key);
+                    toolPerformedAction = true;
+                    VerificationSystem.updateStatus(null, true, "Tile Borrado", `Coordenadas: [${col}, ${row}]`);
+                }
+                // Don't break or return, allow erasing from multiple layers at once
             }
-
-            lastPaintedCoords = { col, row };
-            tilemapRenderer.setDirty();
-
-            // After painting, find the collider and regenerate its mesh
-            const collider = tilemapMateria.getComponent(Components.TilemapCollider2D);
-            if (collider) {
-                collider.generateMesh();
-            }
-
-            return;
         }
+    }
+
+    if (toolPerformedAction) {
+        if (activeTool === 'tile-eraser') {
+            lastPaintedCoords = { col: -1, row: -1 }; // Reset to allow continuous erasing if mouse moves back
+        }
+
+        tilemapRenderer.setDirty();
+        const collider = tilemapMateria.getComponent(Components.TilemapCollider2D);
+        if (collider) {
+            collider.generateMesh();
+        }
+        return;
     }
     VerificationSystem.updateStatus(null, false, "Info: El clic no cayó dentro de los límites de ninguna capa del tilemap.");
 }

--- a/js/editor/ui/TilePaletteWindow.js
+++ b/js/editor/ui/TilePaletteWindow.js
@@ -1,6 +1,7 @@
 import { getURLForAssetPath, getFileHandleForPath } from '../../engine/AssetUtils.js';
-let allTiles = [];
 import { showNotification, showConfirmation, showSelection } from './DialogWindow.js';
+
+let allTiles = [];
 
 const PALETTE_TILE_SIZE = 32;
 let dom = {};

--- a/js/editor/ui/TilePaletteWindow.js
+++ b/js/editor/ui/TilePaletteWindow.js
@@ -146,25 +146,37 @@ export async function openPalette(fileHandle) {
 }
 
 export function getSelectedTile() {
-    // For rectangle tool, return all selected tiles
+    // For rectangle selection tool, return all selected tiles with relative offsets
     if (activeTool === 'tile-rectangle-fill' && selectedTileIds.length > 0) {
-        return selectedTileIds.map(id => {
+        let minX = Infinity, minY = Infinity;
+        const tilesWithCoords = selectedTileIds.map(id => {
             const tile = allTiles[id];
             if (!tile) return null;
-            return {
-                spriteName: tile.spriteName,
-                imageData: tile.imageData,
-                coord: tile.coord
-            };
+            const [x, y] = tile.coord.split(',').map(Number);
+            minX = Math.min(minX, x);
+            minY = Math.min(minY, y);
+            return { ...tile, x, y };
         }).filter(Boolean);
+
+        return tilesWithCoords.map(tile => ({
+            spriteName: tile.spriteName,
+            imageData: tile.imageData,
+            type: tile.type || 'sprite',
+            animationPath: tile.animationPath || null,
+            offsetX: tile.x - minX,
+            offsetY: tile.y - minY
+        }));
     }
     // For brush tool, CONSISTENTLY return the single selected tile in an array
-    else if (activeTool === 'tile-brush' && selectedTileId !== -1 && allTiles[selectedTileId]) {
+    else if ((activeTool === 'tile-brush' || activeTool === 'tile-bucket') && selectedTileId !== -1 && allTiles[selectedTileId]) {
         const tile = allTiles[selectedTileId];
         return [{ // Always return an array
             spriteName: tile.spriteName,
             imageData: tile.imageData,
-            coord: tile.coord
+            type: tile.type || 'sprite',
+            animationPath: tile.animationPath || null,
+            offsetX: 0,
+            offsetY: 0
         }];
     }
     // No valid selection
@@ -178,7 +190,7 @@ export function getActiveTool() {
 export function setActiveTool(toolName) {
     // This function allows external modules to set the palette's active tool.
     // Ensure the tool is valid for the palette.
-    const validTools = ['tile-brush', 'tile-rectangle-fill', 'tile-eraser', 'organize'];
+    const validTools = ['tile-brush', 'tile-rectangle-fill', 'tile-bucket', 'tile-eraser', 'organize'];
     if (!validTools.includes(toolName)) return;
 
     // Don't do anything if organize mode is active and a paint tool is selected
@@ -225,9 +237,9 @@ function setupEventListeners() {
                 currentPalette.associatedSpritePacks.push(fullPath);
                 await loadAndDisplayAssociatedSprites();
             } else {
-                showNotification('Aviso', 'Este paquete de sprites ya está asociado.');
+                showNotification('Aviso', 'Este asset ya está asociado.');
             }
-        }, ['.ceSprite']);
+        }, ['.ceSprite', 'image', '.cea']);
     });
 
     dom.deleteSpriteBtn.addEventListener('click', () => {
@@ -340,7 +352,9 @@ function setupEventListeners() {
         if (e.target.matches('.sidebar-sprite-preview')) {
             draggedSpriteData = {
                 spriteName: e.target.dataset.spriteName,
-                imageData: e.target.dataset.imageData
+                imageData: e.target.dataset.imageData,
+                type: e.target.dataset.type || 'sprite',
+                animationPath: e.target.dataset.animationPath || null
             };
             e.dataTransfer.effectAllowed = 'copy';
         }
@@ -398,7 +412,7 @@ function toggleOrganizeMode() {
     dom.organizeSidebar.classList.toggle('hidden', !isOrganizeMode);
 
     // Hide/show relevant parts of the main toolbar bubble
-    dom.panel.querySelector('.tool-bubble').querySelectorAll('[data-tool="tile-brush"], [data-tool="tile-rectangle-fill"], [data-tool="tile-eraser"]').forEach(btn => {
+    dom.panel.querySelector('.tool-bubble').querySelectorAll('[data-tool="tile-brush"], [data-tool="tile-rectangle-fill"], [data-tool="tile-bucket"], [data-tool="tile-eraser"]').forEach(btn => {
         btn.style.display = isOrganizeMode ? 'none' : 'flex';
     });
 
@@ -509,7 +523,12 @@ function handleCanvasMouseDown(event) {
 
             const selectedSprite = dom.spritePackList.querySelector('.selected');
             if (selectedSprite) {
-                const newTileData = { spriteName: selectedSprite.dataset.spriteName, imageData: selectedSprite.dataset.imageData };
+            const newTileData = {
+                spriteName: selectedSprite.dataset.spriteName,
+                imageData: selectedSprite.dataset.imageData,
+                type: selectedSprite.dataset.type || 'sprite',
+                animationPath: selectedSprite.dataset.animationPath || null
+            };
                 currentPalette.tiles[coord] = newTileData;
                 const existingTileIndex = allTiles.findIndex(t => t.coord === coord);
                 if (existingTileIndex > -1) allTiles.splice(existingTileIndex, 1);
@@ -567,59 +586,91 @@ async function loadAndDisplayAssociatedSprites() {
 
     for (const packPath of currentPalette.associatedSpritePacks) {
         let isValid = true;
+        const lowerPath = packPath.toLowerCase();
         try {
-            if (!packPath.toLowerCase().endsWith('.cesprite')) {
-                console.warn(`Invalid association removed: '${packPath}' is not a .ceSprite file.`);
-                isValid = false;
-                wasCleaned = true;
-                continue;
-            }
+            if (lowerPath.endsWith('.cesprite')) {
+                const packFileHandle = await getFileHandleForPath(packPath, projectsDirHandle);
+                const packFile = await packFileHandle.getFile();
+                const packData = JSON.parse(await packFile.text());
 
-            const packFileHandle = await getFileHandleForPath(packPath, projectsDirHandle);
-            const packFile = await packFileHandle.getFile();
-            const packData = JSON.parse(await packFile.text());
-
-            let sourceImage = imageCache.get(packData.sourceImage);
-            if (!sourceImage) {
-                const sourceImagePath = `Assets/${packData.sourceImage}`;
-                const imageUrl = await getURLForAssetPath(sourceImagePath, projectsDirHandle);
-                if (!imageUrl) {
-                    console.error(`Could not get URL for source image '${packData.sourceImage}' in pack '${packPath}'. Skipping.`);
-                    isValid = false;
-                    wasCleaned = true;
-                    continue;
+                let sourceImage = imageCache.get(packData.sourceImage);
+                if (!sourceImage) {
+                    const sourceImagePath = `Assets/${packData.sourceImage}`;
+                    const imageUrl = await getURLForAssetPath(sourceImagePath, projectsDirHandle);
+                    if (!imageUrl) {
+                        console.error(`Could not get URL for source image '${packData.sourceImage}' in pack '${packPath}'. Skipping.`);
+                        isValid = false;
+                        wasCleaned = true;
+                        continue;
+                    }
+                    sourceImage = new Image();
+                    sourceImage.src = imageUrl;
+                    await sourceImage.decode();
+                    imageCache.set(packData.sourceImage, sourceImage);
                 }
-                sourceImage = new Image();
-                sourceImage.src = imageUrl;
-                await sourceImage.decode();
-                imageCache.set(packData.sourceImage, sourceImage);
-            }
 
-            validSpritePacks.push(packPath);
+                validSpritePacks.push(packPath);
 
-            for (const spriteName in packData.sprites) {
-                const spriteData = packData.sprites[spriteName];
-                const canvas = document.createElement('canvas');
-                const tempSize = 64;
-                canvas.width = tempSize;
-                canvas.height = tempSize;
-                const ctx = canvas.getContext('2d');
-                ctx.drawImage(
-                    sourceImage,
-                    spriteData.rect.x, spriteData.rect.y,
-                    spriteData.rect.width, spriteData.rect.height,
-                    0, 0, tempSize, tempSize
-                );
+                for (const spriteName in packData.sprites) {
+                    const spriteData = packData.sprites[spriteName];
+                    const canvas = document.createElement('canvas');
+                    const tempSize = 64;
+                    canvas.width = tempSize;
+                    canvas.height = tempSize;
+                    const ctx = canvas.getContext('2d');
+                    ctx.drawImage(
+                        sourceImage,
+                        spriteData.rect.x, spriteData.rect.y,
+                        spriteData.rect.width, spriteData.rect.height,
+                        0, 0, tempSize, tempSize
+                    );
 
+                    const img = new Image();
+                    img.src = canvas.toDataURL();
+                    img.title = `${spriteName}\n(${packPath})`;
+                    img.dataset.spriteName = spriteName;
+                    img.dataset.spritePackPath = packPath;
+                    img.dataset.imageData = img.src;
+                    img.classList.add('sidebar-sprite-preview');
+                    img.draggable = true;
+                    dom.spritePackList.appendChild(img);
+                }
+            } else if (lowerPath.endsWith('.cea')) {
+                const animFileHandle = await getFileHandleForPath(packPath, projectsDirHandle);
+                const animData = JSON.parse(await (await animFileHandle.getFile()).text());
+
+                if (animData.frames && animData.frames.length > 0) {
+                    const firstFrame = animData.frames[0];
+                    const img = new Image();
+                    img.src = firstFrame.imageData;
+                    img.title = `${animData.name} (Animación)\n(${packPath})`;
+                    img.dataset.spriteName = animData.name;
+                    img.dataset.spritePackPath = packPath;
+                    img.dataset.imageData = img.src;
+                    img.dataset.type = 'animation';
+                    img.dataset.animationPath = packPath;
+                    img.classList.add('sidebar-sprite-preview');
+                    img.draggable = true;
+                    dom.spritePackList.appendChild(img);
+                    validSpritePacks.push(packPath);
+                }
+            } else if (lowerPath.endsWith('.png') || lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) {
+                const imageUrl = await getURLForAssetPath(packPath, projectsDirHandle);
                 const img = new Image();
-                img.src = canvas.toDataURL();
-                img.title = `${spriteName}\n(${packPath})`;
-                img.dataset.spriteName = spriteName;
+                img.src = imageUrl;
+                const fileName = packPath.split('/').pop();
+                img.title = `${fileName}\n(${packPath})`;
+                img.dataset.spriteName = fileName;
                 img.dataset.spritePackPath = packPath;
-                img.dataset.imageData = img.src;
+                img.dataset.imageData = imageUrl;
                 img.classList.add('sidebar-sprite-preview');
                 img.draggable = true;
                 dom.spritePackList.appendChild(img);
+                validSpritePacks.push(packPath);
+            } else {
+                console.warn(`Association skipped: '${packPath}' format not recognized for palette.`);
+                isValid = false;
+                wasCleaned = true;
             }
 
         } catch (error) {

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -1085,8 +1085,10 @@ export class Animator extends Leyes {
         if (!this.animationClipPath) return;
 
         this.spriteRenderer = this.materia.getComponent(SpriteRenderer);
-        if (!this.spriteRenderer) {
-            console.error('Animator requires a SpriteRenderer component on the same Materia.');
+        const tilemapRenderer = this.materia.getComponent(TilemapRenderer);
+
+        if (!this.spriteRenderer && !tilemapRenderer) {
+            console.warn('Animator requires a SpriteRenderer or TilemapRenderer component on the same Materia.');
             return;
         }
 
@@ -1130,7 +1132,7 @@ export class Animator extends Leyes {
     detener() { this.stop(); }
 
     update(deltaTime) {
-        if (!this.isPlaying || !this.animationClip || !this.spriteRenderer) {
+        if (!this.isPlaying || !this.animationClip) {
             return;
         }
 
@@ -1165,10 +1167,12 @@ export class Animator extends Leyes {
             // Clamp the frame to be safe
             this.currentFrame = Math.max(this.startFrame || 0, Math.min(this.currentFrame, endFrame));
 
-            // Update the SpriteRenderer
-            const spriteName = clip.frames[this.currentFrame];
-            if (this.spriteRenderer.spriteName !== spriteName) {
-                this.spriteRenderer.spriteName = spriteName;
+            // Update the SpriteRenderer if it exists
+            if (this.spriteRenderer) {
+                const spriteName = clip.frames[this.currentFrame];
+                if (this.spriteRenderer.spriteName !== spriteName) {
+                    this.spriteRenderer.spriteName = spriteName;
+                }
             }
         }
     }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -1,5 +1,5 @@
 import * as SceneManager from './SceneManager.js';
-import { Camera, Transform, PointLight2D, SpotLight2D, FreeformLight2D, SpriteLight2D, Tilemap, Grid, Canvas, SpriteRenderer, TilemapRenderer, TextureRender, UITransform, UIImage, UIText, DrawingOrder, Terreno2D, Gyzmo } from './Components.js';
+import { Camera, Transform, PointLight2D, SpotLight2D, FreeformLight2D, SpriteLight2D, Tilemap, Grid, Canvas, SpriteRenderer, TilemapRenderer, Animator, TextureRender, UITransform, UIImage, UIText, DrawingOrder, Terreno2D, Gyzmo } from './Components.js';
 import { getAbsoluteRect, calculateLetterbox } from './UITransformUtils.js';
 export class Renderer {
     constructor(canvas, isEditor = false, isGameView = false) {
@@ -331,16 +331,28 @@ export class Renderer {
         const mapTotalWidth = tilemap.width * grid.cellSize.x;
         const mapTotalHeight = tilemap.height * grid.cellSize.y;
 
+        const animator = tilemapRenderer.materia.getComponent(Animator);
+
         for (const layer of tilemap.layers) {
             const layerOffsetX = layer.position.x * mapTotalWidth;
             const layerOffsetY = layer.position.y * mapTotalHeight;
             for (const [coord, tileData] of layer.tileData.entries()) {
-                const image = tilemapRenderer.getImageForTile(tileData);
+                let image = tilemapRenderer.getImageForTile(tileData);
+
+                // Handle animated tiles
+                if (tileData.type === 'animation' && animator && animator.animationClip && animator.animationClip.frames) {
+                    const frame = animator.animationClip.frames[animator.currentFrame];
+                    if (frame && typeof frame === 'object' && frame.imageData) {
+                        image = tilemapRenderer.getImageForTile(frame);
+                    }
+                }
+
                 if (image && image.complete && image.naturalWidth > 0) {
                     const [x, y] = coord.split(',').map(Number);
                     const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
                     const dy = layerOffsetY + (y * grid.cellSize.y) - (mapTotalHeight / 2);
-                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x, grid.cellSize.y);
+                    // Add a tiny overlap (0.5px) to prevent sub-pixel gaps between tiles
+                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }


### PR DESCRIPTION
He realizado una serie de mejoras y correcciones en el motor, enfocándome en el sistema de Tilemaps y la usabilidad del editor:

1. **Corrección Visual:** Se añadió un pequeño solapamiento (0.5px) al dibujar los azulejos para eliminar las líneas de separación que se veían en la escena.
2. **Cubo de Pintura:** Añadida una nueva herramienta de relleno que permite llenar áreas encerradas con un solo clic.
3. **Pincel Multi-Azulejo:** Ahora puedes seleccionar varios azulejos en la paleta (usando la herramienta de selección rectangular) y pintarlos en la escena manteniendo la forma seleccionada.
4. **Importación Mejorada:** El botón de asociar assets en la paleta ahora permite seleccionar imágenes (.png, .jpg) y archivos de animación (.cea), además de los .ceSprite habituales.
5. **Azulejos Animados:** Si un azulejo es una animación (.cea) y el objeto tiene un componente Animator, los azulejos se animarán automáticamente a la velocidad configurada.
6. **Goma de Borrar:** Se corrigió la lógica para que borre de todas las capas del mapa de azulejos simultáneamente.
7. **Ventanas Bloqueadas:** Se ajustó el CSS de los paneles de Animación, Paleta y Sprites para que los mensajes de "selecciona un archivo" no cubran el encabezado, permitiendo así cerrar las ventanas o usar los controles superiores.

---
*PR created automatically by Jules for task [17761317910911973763](https://jules.google.com/task/17761317910911973763) started by @CarleyInteractiveStudio*