### PR TITLE
Fix Prefs Crash and 2D/3D Coexistence

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -398,6 +398,7 @@ document.addEventListener('DOMContentLoaded', () => {
             'prefs-ai-provider', 'prefs-ai-api-key-group', 'prefs-ai-api-key', 'prefs-ai-save-key-btn', 'prefs-ai-delete-key-btn',
             'prefs-ai-model-selection-group', 'prefs-ai-model-selector', 'prefs-ai-error-display',
             'prefs-carl-can-use-console', 'prefs-carl-can-manage-files', 'prefs-carl-can-manipulate-scenes', 'prefs-carl-can-download-files',
+            'prefs-carl-execution-mode',
             'prefs-execution-mode', 'prefs-auto-close-game-window',
             // Library Window Elements
             'menubar-libraries-btn', 'library-panel', 'library-panel-create-btn', 'library-panel-import-btn', 'library-panel-export-btn',
@@ -1110,21 +1111,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const is3D = currentProjectConfig.rendererMode === '3d-mode' || currentProjectConfig.rendererMode === 'hybrid-3d' || currentProjectConfig.rendererMode === 'anime-3d';
 
         if (dom.sceneCanvas) {
-            dom.sceneCanvas.style.pointerEvents = is3D ? 'none' : 'all';
-            dom.sceneCanvas.style.zIndex = is3D ? '1' : '2';
+            // In hybrid mode, we want both to receive events, but 3D usually takes priority for selection
+            dom.sceneCanvas.style.pointerEvents = (is3D) ? 'none' : 'all';
+            dom.sceneCanvas.style.zIndex = '1'; // Always at bottom to serve as background
         }
         if (dom.sceneCanvas3d) {
             dom.sceneCanvas3d.style.pointerEvents = is3D ? 'all' : 'none';
-            dom.sceneCanvas3d.style.zIndex = is3D ? '2' : '1';
+            dom.sceneCanvas3d.style.zIndex = '2'; // Always on top to allow 3D objects to be seen over 2D
         }
 
         if (dom.gameCanvas) {
-            dom.gameCanvas.style.pointerEvents = is3D ? 'none' : 'all';
-            dom.gameCanvas.style.zIndex = is3D ? '1' : '2';
+            dom.gameCanvas.style.pointerEvents = (is3D) ? 'none' : 'all';
+            dom.gameCanvas.style.zIndex = '1';
         }
         if (dom.gameCanvas3d) {
             dom.gameCanvas3d.style.pointerEvents = is3D ? 'all' : 'none';
-            dom.gameCanvas3d.style.zIndex = is3D ? '2' : '1';
+            dom.gameCanvas3d.style.zIndex = '2';
         }
 
         // Sync 2D/3D toggle button UI
@@ -1646,6 +1648,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     updateScene = function(rendererInstance, isGameView) {
         if (!rendererInstance || !SceneManager.currentScene) return;
+
+        // Sync ambient light from scene
+        if (SceneManager.currentScene.ambiente && SceneManager.currentScene.ambiente.nocheDiaColor) {
+            rendererInstance.setAmbientLight(SceneManager.currentScene.ambiente.nocheDiaColor);
+        }
 
         // --- Pass 1: Draw Scene Geometry ---
         const materiasToRender = SceneManager.currentScene.getAllMaterias()
@@ -2181,11 +2188,18 @@ document.addEventListener('DOMContentLoaded', () => {
         if (isGameRunning && !isGamePaused) {
             runGameLoop();
             if (is3D) {
-                if (renderer3D) renderer3D.render(SceneManager.currentScene, null, { editorCamera: renderer.camera, isToon: currentProjectConfig.rendererMode === 'anime-3d' });
+                // In hybrid mode, we first render 2D as background, then 3D on top
+                if (renderer) updateScene(renderer, false);
+                if (renderer3D) renderer3D.render(SceneManager.currentScene, null, { editorCamera: renderer.camera, isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
+
+                if (gameRenderer) {
+                    gameRenderer.resize();
+                    updateScene(gameRenderer, true);
+                }
                 if (gameRenderer3D) {
                     gameRenderer3D.resize();
                     const mainCam = SceneManager.currentScene.findAllCameras().sort((a,b) => a.getComponent(Components.Camera).depth - b.getComponent(Components.Camera).depth)[0];
-                    if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d' });
+                    if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
                 }
             } else {
                 if (renderer) updateScene(renderer, false);
@@ -2197,16 +2211,21 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             if (activeView === 'scene-content') {
                 if (is3D) {
-                    if (renderer3D) renderer3D.render(SceneManager.currentScene, null, { editorCamera: renderer.camera, isToon: currentProjectConfig.rendererMode === 'anime-3d' });
+                    if (renderer) updateScene(renderer, false);
+                    if (renderer3D) renderer3D.render(SceneManager.currentScene, null, { editorCamera: renderer.camera, isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
                 } else {
                     if (renderer) updateScene(renderer, false);
                 }
             } else if (activeView === 'game-content') {
                 if (is3D) {
+                    if (gameRenderer) {
+                        gameRenderer.resize();
+                        updateScene(gameRenderer, true);
+                    }
                     if (gameRenderer3D) {
                         gameRenderer3D.resize();
                         const mainCam = SceneManager.currentScene.findAllCameras().sort((a,b) => a.getComponent(Components.Camera).depth - b.getComponent(Components.Camera).depth)[0];
-                        if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d' });
+                        if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
                     }
                 } else {
                     if (gameRenderer) updateScene(gameRenderer, true);

--- a/js/editor.js
+++ b/js/editor.js
@@ -1111,22 +1111,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const is3D = currentProjectConfig.rendererMode === '3d-mode' || currentProjectConfig.rendererMode === 'hybrid-3d' || currentProjectConfig.rendererMode === 'anime-3d';
 
         if (dom.sceneCanvas) {
-            // In hybrid mode, we want both to receive events, but 3D usually takes priority for selection
-            dom.sceneCanvas.style.pointerEvents = (is3D) ? 'none' : 'all';
-            dom.sceneCanvas.style.zIndex = '1'; // Always at bottom to serve as background
+            // In hybrid mode, we want both to receive events
+            dom.sceneCanvas.style.pointerEvents = 'all';
+            dom.sceneCanvas.style.zIndex = is3D ? '1' : '2'; // 1 in 3D, 2 in 2D
         }
         if (dom.sceneCanvas3d) {
             dom.sceneCanvas3d.style.pointerEvents = is3D ? 'all' : 'none';
-            dom.sceneCanvas3d.style.zIndex = '2'; // Always on top to allow 3D objects to be seen over 2D
+            dom.sceneCanvas3d.style.zIndex = is3D ? '2' : '1'; // 2 in 3D, 1 in 2D
         }
 
         if (dom.gameCanvas) {
-            dom.gameCanvas.style.pointerEvents = (is3D) ? 'none' : 'all';
-            dom.gameCanvas.style.zIndex = '1';
+            dom.gameCanvas.style.pointerEvents = 'all';
+            dom.gameCanvas.style.zIndex = is3D ? '1' : '2';
         }
         if (dom.gameCanvas3d) {
             dom.gameCanvas3d.style.pointerEvents = is3D ? 'all' : 'none';
-            dom.gameCanvas3d.style.zIndex = '2';
+            dom.gameCanvas3d.style.zIndex = is3D ? '2' : '1';
         }
 
         // Sync 2D/3D toggle button UI
@@ -2199,7 +2199,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (gameRenderer3D) {
                     gameRenderer3D.resize();
                     const mainCam = SceneManager.currentScene.findAllCameras().sort((a,b) => a.getComponent(Components.Camera).depth - b.getComponent(Components.Camera).depth)[0];
-                    if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
+                    if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0, isGameView: true });
                 }
             } else {
                 if (renderer) updateScene(renderer, false);
@@ -2225,7 +2225,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (gameRenderer3D) {
                         gameRenderer3D.resize();
                         const mainCam = SceneManager.currentScene.findAllCameras().sort((a,b) => a.getComponent(Components.Camera).depth - b.getComponent(Components.Camera).depth)[0];
-                        if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0 });
+                        if (mainCam) gameRenderer3D.render(SceneManager.currentScene, mainCam, { isToon: currentProjectConfig.rendererMode === 'anime-3d', clearAlpha: 0, isGameView: true });
                     }
                 } else {
                     if (gameRenderer) updateScene(gameRenderer, true);
@@ -4329,6 +4329,8 @@ public start() {
             SceneManager.currentScene.physicsSystem = physicsSystem; // Link for components
             EngineAPI.CEEngine.initialize({ physicsSystem }); // Pass physics system to the API
             InputManager.initialize(dom.sceneCanvas, dom.gameCanvas);
+            if (dom.sceneCanvas3d) InputManager.attachCanvas(dom.sceneCanvas3d);
+            if (dom.gameCanvas3d) InputManager.attachCanvas(dom.gameCanvas3d);
             UISystem.initialize(SceneManager.currentScene);
 
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1057,16 +1057,15 @@ export function initialize(dependencies) {
     };
 
     // Setup event listeners
-    dom.sceneCanvas.addEventListener('contextmenu', e => {
-        e.preventDefault();
-        e.stopPropagation();
-    });
-    if (dom.sceneCanvas3d) {
-        dom.sceneCanvas3d.addEventListener('contextmenu', e => {
+    const sceneCanvases = [dom.sceneCanvas];
+    if (dom.sceneCanvas3d) sceneCanvases.push(dom.sceneCanvas3d);
+
+    sceneCanvases.forEach(canvas => {
+        canvas.addEventListener('contextmenu', e => {
             e.preventDefault();
             e.stopPropagation();
         });
-    }
+    });
 
     const toggleGizmosBtn = document.getElementById('btn-toggle-gizmos');
     if (toggleGizmosBtn) {
@@ -1078,175 +1077,177 @@ export function initialize(dependencies) {
     }
 
     // --- Drag and Drop Sprite Creation ---
-    dom.sceneCanvas.addEventListener('dragover', (e) => {
-        e.preventDefault(); // Necessary to allow a drop
-        dom.sceneCanvas.classList.add('drag-over-scene');
-    });
+    sceneCanvases.forEach(canvas => {
+        canvas.addEventListener('dragover', (e) => {
+            e.preventDefault(); // Necessary to allow a drop
+            canvas.classList.add('drag-over-scene');
+        });
 
-    dom.sceneCanvas.addEventListener('dragleave', () => {
-        dom.sceneCanvas.classList.remove('drag-over-scene');
-    });
+        canvas.addEventListener('dragleave', () => {
+            canvas.classList.remove('drag-over-scene');
+        });
 
-    dom.sceneCanvas.addEventListener('drop', async (e) => {
-        e.preventDefault();
-        dom.sceneCanvas.classList.remove('drag-over-scene');
+        canvas.addEventListener('drop', async (e) => {
+            e.preventDefault();
+            canvas.classList.remove('drag-over-scene');
 
-        const rect = dom.sceneCanvas.getBoundingClientRect();
-        const canvasPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-        const worldPos = screenToWorld(canvasPos.x, canvasPos.y);
+            const rect = canvas.getBoundingClientRect();
+            const canvasPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+            const worldPos = screenToWorld(canvasPos.x, canvasPos.y);
 
-        // Handle external files from OS
-        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-            let currentDirHandle = getCurrentDirectoryHandle();
-            let currentPath = getCurrentDirectoryPath() || 'Assets';
+            // Handle external files from OS
+            if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                let currentDirHandle = getCurrentDirectoryHandle();
+                let currentPath = getCurrentDirectoryPath() || 'Assets';
 
-            // Fallback to root Assets if no directory is selected
-            if (!currentDirHandle) {
-                try {
-                    const projectName = new URLSearchParams(window.location.search).get('project') || 'TestProject';
-                    const projectsDir = window.projectsDirHandle || projectsDirHandle;
-                    if (!projectsDir) throw new Error("No projects directory handle available.");
-
-                    const projectHandle = await projectsDir.getDirectoryHandle(projectName, { create: true });
-                    currentDirHandle = await projectHandle.getDirectoryHandle('Assets', { create: true });
-                    currentPath = 'Assets';
-                } catch (err) {
-                    console.error("[SceneView] Error al obtener el directorio raíz de Assets:", err);
-                }
-            }
-
-            if (currentDirHandle) {
-                for (const file of e.dataTransfer.files) {
+                // Fallback to root Assets if no directory is selected
+                if (!currentDirHandle) {
                     try {
-                        const targetFileHandle = await currentDirHandle.getFileHandle(file.name, { create: true });
-                        const writable = await targetFileHandle.createWritable();
-                        await writable.write(file);
-                        await writable.close();
+                        const projectName = new URLSearchParams(window.location.search).get('project') || 'TestProject';
+                        const projectsDir = window.projectsDirHandle || projectsDirHandle;
+                        if (!projectsDir) throw new Error("No projects directory handle available.");
 
-                        // Instantiate in scene if it's a video or image
-                        const lowerName = file.name.toLowerCase();
-                        const assetPath = currentPath + '/' + file.name;
-
-                        if (lowerName.endsWith('.mp4') || lowerName.endsWith('.webm') || lowerName.endsWith('.ogv')) {
-                            // Find existing Canvas or create one
-                            let parentCanvas = SceneManager.currentScene.getAllMaterias().find(m => m.getComponent(Components.Canvas));
-                            if (!parentCanvas) {
-                                parentCanvas = MateriaFactory.createCanvasObject();
-                            }
-
-                            const newMateria = MateriaFactory.createBaseMateria(MateriaFactory.generateUniqueName(file.name), parentCanvas);
-                            newMateria.removeComponent(Components.Transform);
-                            const uiTransform = new Components.UITransform(newMateria);
-                            uiTransform.position = { x: worldPos.x, y: worldPos.y }; // Placeholder position
-                            newMateria.addComponent(uiTransform);
-
-                            const videoPlayer = new Components.VideoPlayer(newMateria);
-                            await videoPlayer.setSourcePath(assetPath);
-                            newMateria.addComponent(videoPlayer);
-
-                            // Initialize size if possible
-                            if (videoPlayer.videoWidth > 0) {
-                                videoPlayer.syncSizeToUITransform();
-                            }
-                        }
+                        const projectHandle = await projectsDir.getDirectoryHandle(projectName, { create: true });
+                        currentDirHandle = await projectHandle.getDirectoryHandle('Assets', { create: true });
+                        currentPath = 'Assets';
                     } catch (err) {
-                        console.error("Error al importar archivo desde OS:", err);
+                        console.error("[SceneView] Error al obtener el directorio raíz de Assets:", err);
                     }
                 }
-                if (updateAssetBrowser) await updateAssetBrowser();
-                console.log("Archivos importados con éxito.");
-            }
-            return;
-        }
 
-        try {
-            const dataText = e.dataTransfer.getData('text/plain');
-            if (!dataText) return;
-            const data = JSON.parse(dataText);
+                if (currentDirHandle) {
+                    for (const file of e.dataTransfer.files) {
+                        try {
+                            const targetFileHandle = await currentDirHandle.getFileHandle(file.name, { create: true });
+                            const writable = await targetFileHandle.createWritable();
+                            await writable.write(file);
+                            await writable.close();
 
-            let newMateria = null;
+                            // Instantiate in scene if it's a video or image
+                            const lowerName = file.name.toLowerCase();
+                            const assetPath = currentPath + '/' + file.name;
 
-            if (data.type === 'sprite') {
-                // Create a new Materia at the drop position
-                newMateria = new Materia(data.spriteName);
-                newMateria.addComponent(new Components.Transform(newMateria));
-                const transform = newMateria.getComponent(Components.Transform);
-                transform.x = worldPos.x;
-                transform.y = worldPos.y;
-
-                // Add and configure the SpriteRenderer
-                const spriteRenderer = new Components.SpriteRenderer(newMateria);
-                await spriteRenderer.setSourcePath(data.assetPath, window.projectsDirHandle); // This will load the .ceSprite
-                spriteRenderer.spriteName = data.spriteName; // Set the specific sprite to render
-                newMateria.addComponent(spriteRenderer);
-
-                SceneManager.currentScene.addMateria(newMateria);
-            } else if (data.type === 'Asset' && data.name.endsWith('.ceprefab')) {
-                newMateria = await SceneManager.instantiatePrefabFromPath(data.path, worldPos.x, worldPos.y);
-            } else if (data.type === 'Asset' && (data.name.endsWith('.mp4') || data.name.endsWith('.webm') || data.name.endsWith('.ogv'))) {
-                // Find existing Canvas or create one
-                let parentCanvas = SceneManager.currentScene.getAllMaterias().find(m => m.getComponent(Components.Canvas));
-                if (!parentCanvas) {
-                    parentCanvas = MateriaFactory.createCanvasObject();
-                }
-
-                newMateria = MateriaFactory.createBaseMateria(MateriaFactory.generateUniqueName(data.name), parentCanvas);
-                newMateria.removeComponent(Components.Transform);
-                const uiTransform = new Components.UITransform(newMateria);
-                uiTransform.position = { x: worldPos.x, y: worldPos.y };
-                newMateria.addComponent(uiTransform);
-
-                const videoPlayer = new Components.VideoPlayer(newMateria);
-                await videoPlayer.setSourcePath(data.path);
-                newMateria.addComponent(videoPlayer);
-
-                // Initialize size if possible
-                if (videoPlayer.videoWidth > 0) {
-                    videoPlayer.syncSizeToUITransform();
-                }
-            }
-
-            if (newMateria) {
-                // Si el juego está en marcha, inicializar scripts inmediatamente
-                if (window.isGameRunning) {
-                    console.log(`[SceneView] Inicializando scripts para nuevo objeto '${newMateria.name}' en tiempo de ejecución.`);
-                    const initScriptsRecursive = async (mtr) => {
-                        for (const ley of mtr.leyes) {
-                            if (ley instanceof Components.CreativeScript) {
-                                await ley.initializeInstance();
-                                if (ley.isInitialized) {
-                                    try { ley.start(); } catch(e) {}
-                                    try { ley.onEnable(); } catch(e) {}
+                            if (lowerName.endsWith('.mp4') || lowerName.endsWith('.webm') || lowerName.endsWith('.ogv')) {
+                                // Find existing Canvas or create one
+                                let parentCanvas = SceneManager.currentScene.getAllMaterias().find(m => m.getComponent(Components.Canvas));
+                                if (!parentCanvas) {
+                                    parentCanvas = MateriaFactory.createCanvasObject();
                                 }
-                            } else if (ley instanceof Components.AnimatorController) {
-                                await ley.initialize(window.projectsDirHandle);
-                            } else if (ley instanceof Components.Animator) {
-                                if (!mtr.getComponent(Components.AnimatorController)) {
-                                    await ley.loadAnimationClip(window.projectsDirHandle);
-                                    if (ley.playOnAwake) ley.play();
-                                }
-                            } else if (ley instanceof Components.Terreno2D) {
-                                await ley.loadTextures(window.projectsDirHandle);
-                            }
 
-                            if (!(ley instanceof Components.CreativeScript) && typeof ley.start === 'function') {
-                                try { await ley.start(); } catch(e) {}
+                                const newMateria = MateriaFactory.createBaseMateria(MateriaFactory.generateUniqueName(file.name), parentCanvas);
+                                newMateria.removeComponent(Components.Transform);
+                                const uiTransform = new Components.UITransform(newMateria);
+                                uiTransform.position = { x: worldPos.x, y: worldPos.y }; // Placeholder position
+                                newMateria.addComponent(uiTransform);
+
+                                const videoPlayer = new Components.VideoPlayer(newMateria);
+                                await videoPlayer.setSourcePath(assetPath);
+                                newMateria.addComponent(videoPlayer);
+
+                                // Initialize size if possible
+                                if (videoPlayer.videoWidth > 0) {
+                                    videoPlayer.syncSizeToUITransform();
+                                }
                             }
+                        } catch (err) {
+                            console.error("Error al importar archivo desde OS:", err);
                         }
-                        for (const child of mtr.children) {
-                            await initScriptsRecursive(child);
-                        }
-                    };
-                    await initScriptsRecursive(newMateria);
+                    }
+                    if (updateAssetBrowser) await updateAssetBrowser();
+                    console.log("Archivos importados con éxito.");
+                }
+                return;
+            }
+
+            try {
+                const dataText = e.dataTransfer.getData('text/plain');
+                if (!dataText) return;
+                const data = JSON.parse(dataText);
+
+                let newMateria = null;
+
+                if (data.type === 'sprite') {
+                    // Create a new Materia at the drop position
+                    newMateria = new Materia(data.spriteName);
+                    newMateria.addComponent(new Components.Transform(newMateria));
+                    const transform = newMateria.getComponent(Components.Transform);
+                    transform.x = worldPos.x;
+                    transform.y = worldPos.y;
+
+                    // Add and configure the SpriteRenderer
+                    const spriteRenderer = new Components.SpriteRenderer(newMateria);
+                    await spriteRenderer.setSourcePath(data.assetPath, window.projectsDirHandle); // This will load the .ceSprite
+                    spriteRenderer.spriteName = data.spriteName; // Set the specific sprite to render
+                    newMateria.addComponent(spriteRenderer);
+
+                    SceneManager.currentScene.addMateria(newMateria);
+                } else if (data.type === 'Asset' && data.name.endsWith('.ceprefab')) {
+                    newMateria = await SceneManager.instantiatePrefabFromPath(data.path, worldPos.x, worldPos.y);
+                } else if (data.type === 'Asset' && (data.name.endsWith('.mp4') || data.name.endsWith('.webm') || data.name.endsWith('.ogv'))) {
+                    // Find existing Canvas or create one
+                    let parentCanvas = SceneManager.currentScene.getAllMaterias().find(m => m.getComponent(Components.Canvas));
+                    if (!parentCanvas) {
+                        parentCanvas = MateriaFactory.createCanvasObject();
+                    }
+
+                    newMateria = MateriaFactory.createBaseMateria(MateriaFactory.generateUniqueName(data.name), parentCanvas);
+                    newMateria.removeComponent(Components.Transform);
+                    const uiTransform = new Components.UITransform(newMateria);
+                    uiTransform.position = { x: worldPos.x, y: worldPos.y };
+                    newMateria.addComponent(uiTransform);
+
+                    const videoPlayer = new Components.VideoPlayer(newMateria);
+                    await videoPlayer.setSourcePath(data.path);
+                    newMateria.addComponent(videoPlayer);
+
+                    // Initialize size if possible
+                    if (videoPlayer.videoWidth > 0) {
+                        videoPlayer.syncSizeToUITransform();
+                    }
                 }
 
-                // Refresh UI
-                selectMateria(newMateria);
-                updateInspector();
+                if (newMateria) {
+                    // Si el juego está en marcha, inicializar scripts inmediatamente
+                    if (window.isGameRunning) {
+                        console.log(`[SceneView] Inicializando scripts para nuevo objeto '${newMateria.name}' en tiempo de ejecución.`);
+                        const initScriptsRecursive = async (mtr) => {
+                            for (const ley of mtr.leyes) {
+                                if (ley instanceof Components.CreativeScript) {
+                                    await ley.initializeInstance();
+                                    if (ley.isInitialized) {
+                                        try { ley.start(); } catch(e) {}
+                                        try { ley.onEnable(); } catch(e) {}
+                                    }
+                                } else if (ley instanceof Components.AnimatorController) {
+                                    await ley.initialize(window.projectsDirHandle);
+                                } else if (ley instanceof Components.Animator) {
+                                    if (!mtr.getComponent(Components.AnimatorController)) {
+                                        await ley.loadAnimationClip(window.projectsDirHandle);
+                                        if (ley.playOnAwake) ley.play();
+                                    }
+                                } else if (ley instanceof Components.Terreno2D) {
+                                    await ley.loadTextures(window.projectsDirHandle);
+                                }
+
+                                if (!(ley instanceof Components.CreativeScript) && typeof ley.start === 'function') {
+                                    try { await ley.start(); } catch(e) {}
+                                }
+                            }
+                            for (const child of mtr.children) {
+                                await initScriptsRecursive(child);
+                            }
+                        };
+                        await initScriptsRecursive(newMateria);
+                    }
+
+                    // Refresh UI
+                    selectMateria(newMateria);
+                    updateInspector();
+                }
+            } catch (error) {
+                console.error("Error al soltar el sprite:", error);
             }
-        } catch (error) {
-            console.error("Error al soltar el sprite:", error);
-        }
+        });
     });
 
 
@@ -1270,7 +1271,8 @@ export function initialize(dependencies) {
         }
     });
 
-    dom.sceneCanvas.addEventListener('wheel', (event) => {
+    sceneCanvases.forEach(canvas => {
+        canvas.addEventListener('wheel', (event) => {
         event.preventDefault(); // Stop the browser from scrolling the page
 
         if (!renderer || !renderer.camera) return;
@@ -1288,7 +1290,7 @@ export function initialize(dependencies) {
         renderer.camera.zoom = Math.max(0.001, Math.min(renderer.camera.zoom, 1000.0));
     }, { passive: false });
 
-    dom.sceneCanvas.addEventListener('mousedown', (e) => {
+    canvas.addEventListener('mousedown', (e) => {
         // --- Layer Placement Logic ---
         if (isAddingLayer) {
             e.stopPropagation();
@@ -1340,10 +1342,13 @@ export function initialize(dependencies) {
             return;
         }
 
-        // --- Panning Logic (Middle or Right-click) ---
-        if (e.button === 1 || e.button === 2) {
+        // --- Panning Logic (Middle click or Right-click in 2D) ---
+        const config = getCurrentProjectConfig();
+        const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
+
+        if (e.button === 1 || (e.button === 2 && !is3D)) {
             e.preventDefault();
-            dom.sceneCanvas.style.cursor = 'grabbing';
+            canvas.style.cursor = 'grabbing';
             let lastPos = { x: e.clientX, y: e.clientY };
 
             const onPanMove = (moveEvent) => {
@@ -1358,7 +1363,7 @@ export function initialize(dependencies) {
             };
             const onPanEnd = (upEvent) => {
                 upEvent.preventDefault();
-                dom.sceneCanvas.style.cursor = 'grab';
+                canvas.style.cursor = 'grab';
                 window.removeEventListener('mousemove', onPanMove);
                 window.removeEventListener('mouseup', onPanEnd);
             };
@@ -1509,6 +1514,7 @@ export function initialize(dependencies) {
             }
         }
     });
+    });
 
 }
 
@@ -1526,15 +1532,15 @@ function handle3DCameraNavigation() {
     if (!renderer || !renderer.camera) return;
     const cam = renderer.camera;
     const dt = getDeltaTime();
-    const speed = 5.0 * (InputManager.getKey('Shift') ? 2.0 : 1.0);
+    const speed = 10.0 * (InputManager.getKey('Shift') ? 2.0 : 1.0);
     const rotSpeed = 0.2;
 
     // Movement
     const moveDir = vec3.create();
-    if (InputManager.getKey('w')) moveDir[2] += 1;
-    if (InputManager.getKey('s')) moveDir[2] -= 1;
-    if (InputManager.getKey('a')) moveDir[0] += 1;
-    if (InputManager.getKey('d')) moveDir[0] -= 1;
+    if (InputManager.getKey('w')) moveDir[2] -= 1;
+    if (InputManager.getKey('s')) moveDir[2] += 1;
+    if (InputManager.getKey('a')) moveDir[0] -= 1;
+    if (InputManager.getKey('d')) moveDir[0] += 1;
     if (InputManager.getKey('q')) moveDir[1] -= 1;
     if (InputManager.getKey('e')) moveDir[1] += 1;
 
@@ -1555,9 +1561,12 @@ function handle3DCameraNavigation() {
     // Rotation (Mouse look with right click)
     if (InputManager.getMouseButton(2)) {
         const delta = InputManager.getMouseDelta();
+        // Standard First Person Look
         cam.rotation.y -= delta.x * rotSpeed;
         cam.rotation.x -= delta.y * rotSpeed;
         cam.rotation.x = Math.max(-89, Math.min(89, cam.rotation.x));
+    } else if (InputManager.getMouseButton(1)) {
+        // Orbit/Pan alternative if needed, but let's stick to Right Click for look
     }
 }
 

--- a/js/editor/ui/InspectorWindow.js
+++ b/js/editor/ui/InspectorWindow.js
@@ -1660,6 +1660,11 @@ async function updateInspectorForMateria(selectedMateria) {
                         <label data-i18n="PROP_ORDER_IN_LAYER">${L.get('PROP_ORDER_IN_LAYER', 'Order in Layer')}</label>
                         <input type="number" class="prop-input" step="1" data-component="TextureRender" data-prop="orderInLayer" value="${ley.orderInLayer || 0}">
                     </div>
+                    <hr>
+                    <div class="checkbox-field">
+                        <input type="checkbox" class="prop-input" data-component="TextureRender" data-prop="billboard" ${ley.billboard ? 'checked' : ''}>
+                        <label data-i18n="PROP_BILLBOARD">Billboard (Mirar siempre a cámara)</label>
+                    </div>
                 </div>
             `;
         } else if (ley instanceof Components.VerticalLayoutGroup || ley instanceof Components.HorizontalLayoutGroup) {
@@ -2406,6 +2411,11 @@ async function updateInspectorForMateria(selectedMateria) {
                     <div class="prop-row-multi">
                         <label data-i18n="PROP_ORDER_IN_LAYER">${L.get('PROP_ORDER_IN_LAYER', 'Order in Layer')}</label>
                         <input type="number" class="prop-input" step="1" data-component="SpriteRenderer" data-prop="orderInLayer" value="${ley.orderInLayer || 0}">
+                    </div>
+                    <hr>
+                    <div class="checkbox-field">
+                        <input type="checkbox" class="prop-input" data-component="SpriteRenderer" data-prop="billboard" ${ley.billboard ? 'checked' : ''}>
+                        <label data-i18n="PROP_BILLBOARD">Billboard (Mirar siempre a cámara)</label>
                     </div>
                 </div>`;
         }

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -1658,6 +1658,7 @@ export class SpriteRenderer extends Leyes {
         this.isLoading = false;
         this._lastLoadedSource = '';
         this.pivot = { x: 0.5, y: 0.5 };
+        this.billboard = false; // For 3D mode
     }
 
     get spriteName() { return this._spriteName; }
@@ -3007,6 +3008,7 @@ export class TextureRender extends Leyes {
         this._lastLoadedPath = '';
         this.isLoading = false;
         this.isError = false;
+        this.billboard = false; // For 3D mode
     }
 
     update(deltaTime) {

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -112,6 +112,10 @@ export class Renderer {
         if (cameraComponent && cameraComponent.clearFlags === 'SolidColor') {
             this.ctx.fillStyle = cameraComponent.backgroundColor;
             this.ctx.fillRect(x, y, w, h);
+        } else if (!cameraComponent && this.isEditor) {
+            // In editor mode with no specific camera, use ambient light as background
+            this.ctx.fillStyle = this.ambientLight;
+            this.ctx.fillRect(x, y, w, h);
         } else {
             this.ctx.clearRect(x, y, w, h);
         }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -112,10 +112,9 @@ export class Renderer {
         if (cameraComponent && cameraComponent.clearFlags === 'SolidColor') {
             this.ctx.fillStyle = cameraComponent.backgroundColor;
             this.ctx.fillRect(x, y, w, h);
-        } else if (!cameraComponent && this.isEditor) {
-            // In editor mode with no specific camera, use ambient light as background
-            this.ctx.fillStyle = this.ambientLight;
-            this.ctx.fillRect(x, y, w, h);
+        } else if (!cameraComponent && this.isEditor && !this.isGameView) {
+            // In editor mode with no specific camera, clear to transparent to show CSS background
+            this.ctx.clearRect(x, y, w, h);
         } else {
             this.ctx.clearRect(x, y, w, h);
         }

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -290,7 +290,13 @@ export class Renderer3D {
         const bgColor = this.hexToRgb(ambiente.nocheDiaColor || '#1a1a2a');
 
         // Allow transparency for hybrid modes
-        const alpha = (options.clearAlpha !== undefined) ? options.clearAlpha : 1.0;
+        let alpha = (options.clearAlpha !== undefined) ? options.clearAlpha : 1.0;
+
+        // In editor mode without specific camera, be transparent to show CSS grey background
+        if (!cameraMateria && !options.isGameView) {
+            alpha = 0.0;
+        }
+
         gl.clearColor(bgColor[0], bgColor[1], bgColor[2], alpha);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
@@ -301,6 +307,7 @@ export class Renderer3D {
         this.lastViewMatrix = viewMatrix;
 
         let is3DView = true;
+        let activeViewPosition = [0, 0, 0];
 
         if (cameraMateria) {
             const camComp = cameraMateria.getComponent(Camera);
@@ -317,7 +324,8 @@ export class Renderer3D {
 
             const q = quat.create();
             quat.fromEuler(q, camTrans.localRotation.x, camTrans.localRotation.y, camTrans.localRotation.z);
-            mat4.fromRotationTranslation(viewMatrix, q, [camTrans.x, camTrans.y, camTrans.z]);
+            activeViewPosition = [camTrans.x, camTrans.y, camTrans.z];
+            mat4.fromRotationTranslation(viewMatrix, q, activeViewPosition);
             mat4.invert(viewMatrix, viewMatrix);
         } else {
             // Editor default camera
@@ -326,16 +334,18 @@ export class Renderer3D {
 
             // In Renderer.js, this.camera in editor has {x, y, z, rotation: {x, y, z}, zoom}
             // Use a default Z that allows seeing 2D objects at Z=0
-            const editorCam = options.editorCamera || { x: 0, y: 0, z: 1000, rotation: { x: 0, y: 0, z: 0 } };
+            const editorCam = options.editorCamera || { x: 0, y: 0, z: 500, rotation: { x: 0, y: 0, z: 0 } };
             const q = quat.create();
             quat.fromEuler(q, editorCam.rotation.x, editorCam.rotation.y, editorCam.rotation.z);
 
             // Adjust camera position to be compatible with 2D world coordinates (which are often large)
-            mat4.fromRotationTranslation(viewMatrix, q, [editorCam.x, editorCam.y, editorCam.z]);
+            activeViewPosition = [editorCam.x, editorCam.y, editorCam.z];
+            mat4.fromRotationTranslation(viewMatrix, q, activeViewPosition);
             mat4.invert(viewMatrix, viewMatrix);
         }
 
         gl.useProgram(this.programInfo.program);
+        gl.uniform3fv(this.programInfo.uniformLocations.viewPosition, activeViewPosition);
 
         // Global Lights Setup
         const dirLight = scene.getAllMaterias().find(m => m.isActive && m.getComponent(Components.DirectionalLight3D));
@@ -483,7 +493,17 @@ export class Renderer3D {
 
             const spriteModelMatrix = mat4.create();
             const spriteScale = [scale[0] * spriteScaleX, scale[1] * spriteScaleY, 1];
-            mat4.fromRotationTranslationScale(spriteModelMatrix, q, pos, spriteScale);
+
+            let finalRotation = q;
+            if (spriteRenderer.billboard && !options.picking) {
+                // To billboard, we take the view matrix and invert its rotation
+                const viewRot = quat.create();
+                mat4.getRotation(viewRot, viewMatrix);
+                quat.invert(viewRot, viewRot);
+                finalRotation = viewRot;
+            }
+
+            mat4.fromRotationTranslationScale(spriteModelMatrix, finalRotation, pos, spriteScale);
             gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, spriteModelMatrix);
 
             gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
@@ -526,7 +546,16 @@ export class Renderer3D {
 
             const modelMatrixTex = mat4.create();
             const texScale = [scale[0] * textureRender.width, scale[1] * textureRender.height, 1];
-            mat4.fromRotationTranslationScale(modelMatrixTex, q, pos, texScale);
+
+            let finalRotationTex = q;
+            if (textureRender.billboard && !options.picking) {
+                const viewRot = quat.create();
+                mat4.getRotation(viewRot, viewMatrix);
+                quat.invert(viewRot, viewRot);
+                finalRotationTex = viewRot;
+            }
+
+            mat4.fromRotationTranslationScale(modelMatrixTex, finalRotationTex, pos, texScale);
             gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, modelMatrixTex);
 
             gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -289,7 +289,9 @@ export class Renderer3D {
         const ambiente = scene.ambiente || {};
         const bgColor = this.hexToRgb(ambiente.nocheDiaColor || '#1a1a2a');
 
-        gl.clearColor(bgColor[0], bgColor[1], bgColor[2], 1.0);
+        // Allow transparency for hybrid modes
+        const alpha = (options.clearAlpha !== undefined) ? options.clearAlpha : 1.0;
+        gl.clearColor(bgColor[0], bgColor[1], bgColor[2], alpha);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         const projectionMatrix = mat4.create();
@@ -372,17 +374,18 @@ export class Renderer3D {
     }
 
     renderMateria(materia, projectionMatrix, viewMatrix, options) {
-        if (options.picking && !materia.getComponent(Components.MeshRenderer3D) && !materia.getComponent(Components.SpriteRenderer)) return;
+        const meshRenderer = materia.getComponent(Components.MeshRenderer3D);
+        const spriteRenderer = materia.getComponent(Components.SpriteRenderer);
+        const textureRender = materia.getComponent(Components.TextureRender);
+
+        if (options.picking && !meshRenderer && !spriteRenderer && !textureRender) return;
 
         const gl = this.gl;
         const programInfo = options.picking ? this.pickingProgramInfo : this.programInfo;
         const transform = materia.getComponent(Transform);
         if (!transform || !materia.isActive) return;
 
-        const meshRenderer = materia.getComponent(Components.MeshRenderer3D);
-        const spriteRenderer = materia.getComponent(Components.SpriteRenderer);
-
-        if (!meshRenderer && !spriteRenderer) return;
+        if (!meshRenderer && !spriteRenderer && !textureRender) return;
 
         const modelMatrix = mat4.create();
         const pos = [transform.x, transform.y, transform.z || 0];
@@ -413,6 +416,9 @@ export class Renderer3D {
         } else if (spriteRenderer) {
             const rgb = this.hexToRgb(spriteRenderer.color);
             color = [rgb[0], rgb[1], rgb[2], spriteRenderer.opacity !== undefined ? spriteRenderer.opacity : 1.0];
+        } else if (textureRender) {
+            const rgb = this.hexToRgb(textureRender.color);
+            color = [rgb[0], rgb[1], rgb[2], 1.0];
         }
 
         gl.uniform4fv(this.programInfo.uniformLocations.uColor, color);
@@ -479,6 +485,49 @@ export class Renderer3D {
             const spriteScale = [scale[0] * spriteScaleX, scale[1] * spriteScaleY, 1];
             mat4.fromRotationTranslationScale(spriteModelMatrix, q, pos, spriteScale);
             gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, spriteModelMatrix);
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
+            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
+            gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeNormalBuffer);
+            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
+
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
+            gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+        } else if (textureRender) {
+            if (options.picking) {
+                const id = options.idMap.get(materia.id);
+                const pickingColor = [
+                    ((id >>  0) & 0xFF) / 255,
+                    ((id >>  8) & 0xFF) / 255,
+                    ((id >> 16) & 0xFF) / 255,
+                    1.0
+                ];
+                gl.uniform4fv(programInfo.uniformLocations.uPickingColor, pickingColor);
+            }
+
+            if (!options.picking) {
+                const tex = this.getGLTexture(textureRender.texture);
+                if (tex) {
+                    gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 1);
+                    gl.activeTexture(gl.TEXTURE0);
+                    gl.bindTexture(gl.TEXTURE_2D, tex);
+                    gl.uniform1i(this.programInfo.uniformLocations.uSampler, 0);
+                } else {
+                    gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 0);
+                }
+            }
+
+            const modelMatrixTex = mat4.create();
+            const texScale = [scale[0] * textureRender.width, scale[1] * textureRender.height, 1];
+            mat4.fromRotationTranslationScale(modelMatrixTex, q, pos, texScale);
+            gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, modelMatrixTex);
 
             gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
             gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);


### PR DESCRIPTION
This update resolves a reported crash when saving preferences and implements a more robust hybrid rendering system. 

Previously, switching to 3D mode would hide all 2D elements and cause inconsistent background colors. Now, the 2D layer (including Tilemaps and Terrain) is rendered first as a background, and the 3D layer is rendered on top with transparency enabled for empty areas. 

Additionally, we fixed a JavaScript error in the preferences window caused by a missing UI element registration for the Carl IA execution mode.

---
*PR created automatically by Jules for task [4114645244991290273](https://jules.google.com/task/4114645244991290273) started by @CarleyInteractiveStudio*