### PR TITLE
Fix 3D Gizmos, Renderer, and Navigation Bugs

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1483,6 +1483,10 @@ public star() {
                         <input type="checkbox" id="prefs-show-scene-grid" checked>
                         <label for="prefs-show-scene-grid" data-i18n="MOSTRAR_CUADRICULA">Mostrar cuadrícula de la escena</label>
                     </div>
+                    <div class="checkbox-field">
+                        <input type="checkbox" id="prefs-show-origin-axes" checked>
+                        <label for="prefs-show-origin-axes">Mostrar Ejes de Origen (X, Y, Z)</label>
+                    </div>
                     <hr>
                     <div class="checkbox-field">
                         <input type="checkbox" id="prefs-snapping-toggle">

--- a/js/editor.js
+++ b/js/editor.js
@@ -492,7 +492,7 @@ document.addEventListener('DOMContentLoaded', () => {
             'prefs-smart-reparator-toggle', 'code-creative-code-toggle',
             // Animation Skeletal Elements
             'animation-type-selector', 'animation-record-btn', 'skeletal-timeline', 'animation-time-slider', 'skeletal-tracks',
-            'scene-canvas-3d', 'game-canvas-3d'
+            'scene-canvas-3d', 'game-canvas-3d', 'prefs-show-origin-axes'
         ];
         ids.forEach(id => {
             const camelCaseId = id.replace(/-(\w)/g, (_, c) => c.toUpperCase());

--- a/js/editor.js
+++ b/js/editor.js
@@ -3693,6 +3693,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     // Resize canvas in real-time
                     if (renderer) renderer.resize();
                     if (gameRenderer) gameRenderer.resize();
+                    if (renderer3D) renderer3D.resize();
+                    if (gameRenderer3D) gameRenderer3D.resize();
                 };
 
                 const onPointerUp = (upEvent) => {

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -787,6 +787,13 @@ export function initialize(dependencies) {
         const rect = canvas.getBoundingClientRect();
         const currentMouseWorld = screenToWorld(moveEvent.clientX - rect.left, moveEvent.clientY - rect.top);
 
+        const config = getCurrentProjectConfig();
+        const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
+
+        // In 3D, screen deltas are often more reliable than 2D-world-projection for 3D axes
+        const screenDx = moveEvent.clientX - lastMousePosition.x;
+        const screenDy = moveEvent.clientY - lastMousePosition.y;
+
         const totalDx = (currentMouseWorld.x - dragState.initialMouseWorld.x);
         const totalDy = (currentMouseWorld.y - dragState.initialMouseWorld.y);
 
@@ -801,14 +808,15 @@ export function initialize(dependencies) {
                 break;
             case 'move-x':
                 {
-                    let nextX = dragState.initialTransform.x + totalDx;
+                    let nextX = is3D ? (dragState.initialTransform.x + (moveEvent.clientX - dragState.initialMousePos.x)) : (dragState.initialTransform.x + totalDx);
                     if (snapEnabled) nextX = Math.round(nextX / snapSize) * snapSize;
                     transform.x = nextX;
                 }
                 break;
             case 'move-y':
                 {
-                    let nextY = dragState.initialTransform.y + totalDy;
+                    // In 3D, Y is up, but screen Y is down.
+                    let nextY = is3D ? (dragState.initialTransform.y - (moveEvent.clientY - dragState.initialMousePos.y)) : (dragState.initialTransform.y + totalDy);
                     if (snapEnabled) nextY = Math.round(nextY / snapSize) * snapSize;
                     transform.y = nextY;
                 }
@@ -827,12 +835,31 @@ export function initialize(dependencies) {
                 break;
             case 'move-z':
                 {
-                    // For Z, we use vertical screen delta as a proxy since we're in 2D overlay
-                    const dyPx = (moveEvent.clientY - lastMousePosition.y) / renderer.camera.effectiveZoom;
+                    // In 3D, for Z movement, we also use the world delta logic but since mouse movement is on screen,
+                    // we can't easily map screen space to world Z in a generic way without raycasting.
+                    // However, for consistency with X/Y, we'll use the vertical screen delta as a world proxy.
+                    const dyPx = (moveEvent.clientY - lastMousePosition.y);
                     let nextZ = (transform.z || 0) + dyPx;
                     if (snapEnabled) nextZ = Math.round(nextZ / snapSize) * snapSize;
                     transform.z = nextZ;
                 }
+                break;
+            case 'scale-x':
+                transform.localScale = { ...transform.localScale, x: dragState.initialTransform.scale.x + totalDx / 50 };
+                break;
+            case 'scale-y':
+                transform.localScale = { ...transform.localScale, y: dragState.initialTransform.scale.y - totalDy / 50 };
+                break;
+            case 'scale-z':
+                transform.localScale = { ...transform.localScale, z: dragState.initialTransform.scale.z + (moveEvent.clientY - lastMousePosition.y) / 50 };
+                break;
+            case 'scale-all':
+                const avgScale = 1 + (totalDx - totalDy) / 100;
+                transform.localScale = {
+                    x: dragState.initialTransform.scale.x * avgScale,
+                    y: dragState.initialTransform.scale.y * avgScale,
+                    z: dragState.initialTransform.scale.z * avgScale
+                };
                 break;
             case 'camera-resize-tl': case 'camera-resize-tr': case 'camera-resize-bl': case 'camera-resize-br': {
                 const cam = dragState.materia.getComponent(Components.Camera);
@@ -1544,6 +1571,20 @@ export function initialize(dependencies) {
             const selectedMateria = getSelectedMateria();
             const canvasPos = InputManager.getMousePositionInCanvas();
 
+            // Click and Hold for Focus logic
+            const clickStartTime = performance.now();
+            const startMousePos = { x: e.clientX, y: e.clientY };
+
+            const onPotentialFocusEnd = () => {
+                const duration = performance.now() - clickStartTime;
+                const dist = Math.hypot(InputManager.getMousePosition().x - startMousePos.x, InputManager.getMousePosition().y - startMousePos.y);
+                if (duration > 500 && dist < 10) {
+                     focusOnSelectedMateria();
+                }
+                window.removeEventListener('mouseup', onPotentialFocusEnd);
+            };
+            window.addEventListener('mouseup', onPotentialFocusEnd);
+
             // 3D Object Picking
             const config = getCurrentProjectConfig();
             const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
@@ -1577,7 +1618,8 @@ export function initialize(dependencies) {
                         rotation: transform.rotation,
                         scale: { x: transform.scale.x, y: transform.scale.y, z: transform.scale.z || 1 }
                     } : null,
-                    initialMouseWorld: screenToWorld(canvasPos.x, canvasPos.y)
+                    initialMouseWorld: screenToWorld(canvasPos.x, canvasPos.y),
+                    initialMousePos: { x: e.clientX, y: e.clientY }
                 };
                 lastMousePosition = { x: e.clientX, y: e.clientY };
 
@@ -1632,6 +1674,9 @@ function handle3DCameraNavigation() {
     const isFlying = InputManager.getMouseButton(2);
 
     if (isFlying) {
+        // Prevent browser context menu during flight
+        window.addEventListener('contextmenu', e => e.preventDefault(), { once: true });
+
         // Speed adjustments for larger 3D scenes
         const baseSpeed = 800; // Slightly faster for more responsive feel
         const speed = baseSpeed * (InputManager.getKey('Shift') ? 3.0 : 1.0) * dt;
@@ -1698,6 +1743,35 @@ function handle3DCameraNavigation() {
     }
 }
 
+export function focusOnSelectedMateria() {
+    const materia = getSelectedMateria();
+    if (!materia || !renderer || !renderer.camera) return;
+
+    const transform = materia.getComponent(Components.Transform);
+    if (!transform) return;
+
+    const cam = renderer.camera;
+    const config = getCurrentProjectConfig();
+    const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
+
+    if (is3D) {
+        // Position camera at a comfortable distance (e.g., 200 units) from the object
+        // and look at it.
+        const distance = 300;
+        cam.x = transform.x;
+        cam.y = transform.y + 100; // Slightly above
+        cam.z = (transform.z || 0) + distance;
+        // Looking down slightly
+        cam.rotation.x = 15;
+        cam.rotation.y = 0;
+    } else {
+        cam.x = transform.x;
+        cam.y = transform.y;
+        cam.zoom = 1.0;
+    }
+    updateScene();
+}
+
 export function update() {
     // This will be called from the main editorLoop
     const config = getCurrentProjectConfig();
@@ -1705,6 +1779,9 @@ export function update() {
 
     if (is3D && !window.isGameRunning && getActiveView() === 'scene-content') {
         handle3DCameraNavigation();
+        if (InputManager.getKeyDown('f')) {
+            focusOnSelectedMateria();
+        }
     } else {
         handleEditorInteractions();
     }
@@ -2144,123 +2221,99 @@ function drawLayerPlacementPreview() {
 
 function check3DGizmoHit(canvasPos, materia) {
     const transform = materia.getComponent(Components.Transform);
-    const screenPos = world3DToScreen({ x: transform.x, y: transform.y, z: transform.z });
+    const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
+    const screenPos = world3DToScreen(center);
     if (!screenPos) return null;
 
-    const dx = canvasPos.x - screenPos.x;
-    const dy = canvasPos.y - screenPos.y;
-    const hitRadius = 15;
+    const hitRadius = 20;
+    const gizmoLen = 80;
 
-    if (activeTool === 'move' || activeTool === 'universal') {
-        // Simple 2D-on-3D hit detection
-        if (Math.abs(dx) < hitRadius && Math.abs(dy) < hitRadius) return 'move-xy';
-        if (Math.abs(dx - 50) < hitRadius && Math.abs(dy) < hitRadius) return 'move-x';
-        if (Math.abs(dx) < hitRadius && Math.abs(dy + 50) < hitRadius) return 'move-y';
+    const checkHandle = (worldAxis, name) => {
+        const axisEnd = { x: center.x + worldAxis.x * gizmoLen, y: center.y + worldAxis.y * gizmoLen, z: center.z + worldAxis.z * gizmoLen };
+        const screenEnd = world3DToScreen(axisEnd);
+        if (!screenEnd) return false;
+        const dx = canvasPos.x - screenEnd.x;
+        const dy = canvasPos.y - screenEnd.y;
+        return Math.hypot(dx, dy) < hitRadius;
+    };
 
-        // Check Blue Z axis hit
-        const zEnd = world3DToScreen({ x: transform.x, y: transform.y, z: transform.z + 100 });
-        if (zEnd) {
-            const zDx = canvasPos.x - zEnd.x;
-            const zDy = canvasPos.y - zEnd.y;
-            if (Math.abs(zDx) < hitRadius && Math.abs(zDy) < hitRadius) return 'move-z';
-        }
+    if (activeTool === 'move' || activeTool === 'universal' || activeTool === 'scale') {
+        const dx = canvasPos.x - screenPos.x;
+        const dy = canvasPos.y - screenPos.y;
+        if (Math.hypot(dx, dy) < hitRadius) return activeTool === 'scale' ? 'scale-all' : 'move-xy';
+
+        if (checkHandle({x:1, y:0, z:0}, activeTool === 'scale' ? 'scale-x' : 'move-x')) return activeTool === 'scale' ? 'scale-x' : 'move-x';
+        if (checkHandle({x:0, y:1, z:0}, activeTool === 'scale' ? 'scale-y' : 'move-y')) return activeTool === 'scale' ? 'scale-y' : 'move-y';
+        if (checkHandle({x:0, y:0, z:1}, activeTool === 'scale' ? 'scale-z' : 'move-z')) return activeTool === 'scale' ? 'scale-z' : 'move-z';
     }
     return null;
 }
 
 function draw3DGizmos(materia) {
     const transform = materia.getComponent(Components.Transform);
-    const center = { x: transform.x, y: transform.y, z: transform.z };
+    const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
     const screenPos = world3DToScreen(center);
     if (!screenPos) return;
 
     const { ctx } = renderer;
-    const GIZMO_SIZE = 50;
+    const GIZMO_SIZE = 80;
+    const ARROW_SIZE = 12;
 
-    // Draw Wireframe helpers for 3D Primitives (in 3D projected space)
     const C3D = window.Components3D || Components3D;
     if (!C3D) return;
 
     const meshRenderer = materia.getComponent(C3D.MeshRenderer3D);
     if (meshRenderer) {
-        if (meshRenderer.meshType === 'Cube') {
-            Gizmos.drawWireCube(ctx, center, { x: 100 * transform.scale.x, y: 100 * transform.scale.y, z: 100 * transform.scale.z });
-        } else if (meshRenderer.meshType === 'Sphere') {
-            Gizmos.drawWireSphere(ctx, center, 50 * Math.max(transform.scale.x, transform.scale.y, transform.scale.z));
-        } else if (meshRenderer.meshType === 'Plane') {
-            Gizmos.drawWirePlane(ctx, center, { x: 100 * transform.scale.x, z: 100 * transform.scale.z });
-        } else if (meshRenderer.meshType === 'Triangle') {
-            Gizmos.drawWireTriangle(ctx, center, { x: 100 * transform.scale.x, y: 100 * transform.scale.y });
-        } else if (meshRenderer.meshType === 'Capsule') {
-            Gizmos.drawWireCapsule(ctx, center, 50 * Math.max(transform.scale.x, transform.scale.z), 100 * transform.scale.y);
-        }
+        const mult = 2;
+        if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y, z: mult * transform.scale.z });
+        else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.y, transform.scale.z));
+        else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: mult * transform.scale.x, z: mult * transform.scale.z });
+        else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y });
+        else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.z), mult * transform.scale.y);
     }
 
     ctx.save();
-    ctx.setTransform(1, 0, 0, 1, 0, 0); // Overlay in screen space
-    ctx.translate(screenPos.x, screenPos.y);
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
 
+    const drawAxis = (axis, color, name) => {
+        const endPos = { x: center.x + axis.x * GIZMO_SIZE, y: center.y + axis.y * GIZMO_SIZE, z: center.z + axis.z * GIZMO_SIZE };
+        const endScreen = world3DToScreen(endPos);
+        if (!endScreen) return;
 
-    if (activeTool === 'move' || activeTool === 'universal') {
-        const ARROW_SIZE = 10;
-
-        // Red X
-        ctx.strokeStyle = '#ff4444';
-        ctx.fillStyle = '#ff4444';
+        ctx.strokeStyle = color;
+        ctx.fillStyle = color;
         ctx.lineWidth = 3;
         ctx.beginPath();
-        ctx.moveTo(0, 0);
-        ctx.lineTo(GIZMO_SIZE, 0);
+        ctx.moveTo(screenPos.x, screenPos.y);
+        ctx.lineTo(endScreen.x, endScreen.y);
         ctx.stroke();
-        // X Arrow head
-        ctx.beginPath();
-        ctx.moveTo(GIZMO_SIZE + ARROW_SIZE, 0);
-        ctx.lineTo(GIZMO_SIZE, -ARROW_SIZE / 2);
-        ctx.lineTo(GIZMO_SIZE, ARROW_SIZE / 2);
-        ctx.closePath();
-        ctx.fill();
 
-        // Green Y
-        ctx.strokeStyle = '#44ff44';
-        ctx.fillStyle = '#44ff44';
-        ctx.lineWidth = 3;
+        const angle = Math.atan2(endScreen.y - screenPos.y, endScreen.x - screenPos.x);
+        ctx.save();
+        ctx.translate(endScreen.x, endScreen.y);
+        ctx.rotate(angle);
         ctx.beginPath();
-        ctx.moveTo(0, 0);
-        ctx.lineTo(0, -GIZMO_SIZE);
-        ctx.stroke();
-        // Y Arrow head
-        ctx.beginPath();
-        ctx.moveTo(0, -GIZMO_SIZE - ARROW_SIZE);
-        ctx.lineTo(-ARROW_SIZE / 2, -GIZMO_SIZE);
-        ctx.lineTo(ARROW_SIZE / 2, -GIZMO_SIZE);
-        ctx.closePath();
-        ctx.fill();
-
-        // Blue Z
-        const zEnd = world3DToScreen({ x: transform.x, y: transform.y, z: transform.z + 100 });
-        if (zEnd) {
-            const zDx = zEnd.x - screenPos.x;
-            const zDy = zEnd.y - screenPos.y;
-            ctx.strokeStyle = '#4444ff';
-            ctx.fillStyle = '#4444ff';
-            ctx.beginPath();
-            ctx.moveTo(0, 0);
-            ctx.lineTo(zDx, zDy);
-            ctx.stroke();
-
-            // Z Arrow head (pointing towards zEnd)
-            const angle = Math.atan2(zDy, zDx);
-            ctx.save();
-            ctx.translate(zDx, zDy);
-            ctx.rotate(angle);
-            ctx.beginPath();
+        if (activeTool === 'scale') {
+            ctx.rect(-ARROW_SIZE/2, -ARROW_SIZE/2, ARROW_SIZE, ARROW_SIZE);
+        } else {
             ctx.moveTo(ARROW_SIZE, 0);
             ctx.lineTo(0, -ARROW_SIZE / 2);
             ctx.lineTo(0, ARROW_SIZE / 2);
             ctx.closePath();
-            ctx.fill();
-            ctx.restore();
         }
+        ctx.fill();
+        ctx.restore();
+    };
+
+    if (activeTool === 'move' || activeTool === 'universal' || activeTool === 'scale') {
+        drawAxis({x:1,y:0,z:0}, '#ff4444', 'X');
+        drawAxis({x:0,y:1,z:0}, '#44ff44', 'Y');
+        drawAxis({x:0,y:0,z:1}, '#4444ff', 'Z');
+
+        // Center handle
+        ctx.fillStyle = activeTool === 'scale' ? '#ffffff' : 'rgba(255, 255, 255, 0.5)';
+        ctx.beginPath(); ctx.arc(screenPos.x, screenPos.y, 6, 0, Math.PI * 2); ctx.fill();
+        ctx.strokeStyle = '#000'; ctx.lineWidth = 1; ctx.stroke();
     }
 
     ctx.restore();
@@ -2272,6 +2325,7 @@ export function drawOverlay() {
 
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
+    const is3DActive = is3D && config.viewMode !== '2d';
 
     if (is3D) {
         // Reset 2D transform to Screen Space for 3D-projected gizmos
@@ -2283,8 +2337,11 @@ export function drawOverlay() {
     } else {
         drawEditorGrid();
     }
-    drawComponentGrids();
-    drawLayerPlacementPreview();
+
+    if (!is3DActive) {
+        drawComponentGrids();
+        drawLayerPlacementPreview();
+    }
 
     // Draw gizmo for the selected object
     if (getSelectedMateria()) {
@@ -2304,32 +2361,37 @@ export function drawOverlay() {
         drawGizmoIcons();
     }
 
-    // Draw tile painting cursor
-    drawTileCursor();
+    if (!is3DActive) {
+        // Draw tile painting cursor
+        drawTileCursor();
 
-    // Draw tilemap colliders
-    drawTilemapColliders();
+        // Draw tilemap colliders
+        drawTilemapColliders();
 
-    // Draw terrain colliders
-    drawTerrenoColliders();
+        // Draw terrain colliders
+        drawTerrenoColliders();
 
-    // Draw physics colliders for selected object
-    drawPhysicsGizmos();
+        // Draw physics colliders for selected object
+        drawPhysicsGizmos();
+    }
+
     draw3DPhysicsGizmos();
 
-    // Draw outline for selected Tilemap
-    drawTilemapOutline();
+    if (!is3DActive) {
+        // Draw outline for selected Tilemap
+        drawTilemapOutline();
 
-    // Draw Canvas gizmos
-    drawCanvasGizmos();
-    drawUIGizmos(renderer, getSelectedMateria());
+        // Draw Canvas gizmos
+        drawCanvasGizmos();
+        drawUIGizmos(renderer, getSelectedMateria());
 
-    drawRaycastGizmos();
+        drawRaycastGizmos();
 
-    drawTerrainBrushGizmo();
-    drawWeightPainterGizmo();
+        drawTerrainBrushGizmo();
+        drawWeightPainterGizmo();
 
-    drawBasicAIGizmos();
+        drawBasicAIGizmos();
+    }
 
     if (is3D) {
         renderer.ctx.restore();
@@ -2522,30 +2584,32 @@ function draw3DGrid() {
     }
 
     // Main Axes (Infinite Origin Lines)
-    ctx.lineWidth = 2;
-    const axisLen = 1000000; // Large enough to look infinite
+    if (prefs.showOriginAxes !== false) {
+        ctx.lineWidth = 2;
+        const axisLen = 1000000; // Large enough to look infinite
 
-    // X Axis (Red)
-    drawLine3D({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 50, 50, 0.8)');
+        // X Axis (Red)
+        drawLine3D({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 50, 50, 0.8)');
 
-    // Y Axis (Green)
-    drawLine3D({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(50, 255, 50, 0.8)');
+        // Y Axis (Green)
+        drawLine3D({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(50, 255, 50, 0.8)');
 
-    // Z Axis (Blue)
-    drawLine3D({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(50, 50, 255, 0.8)');
+        // Z Axis (Blue)
+        drawLine3D({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(50, 50, 255, 0.8)');
 
-    // Center Crosshair (Origin Point)
-    const origin = world3DToScreen({ x: 0, y: 0, z: 0 });
-    if (origin) {
-        ctx.fillStyle = "#ffffff";
-        ctx.beginPath(); ctx.arc(origin.x, origin.y, 6, 0, Math.PI * 2); ctx.fill();
-        ctx.strokeStyle = "#000000"; ctx.lineWidth = 2; ctx.stroke();
+        // Center Crosshair (Origin Point)
+        const origin = world3DToScreen({ x: 0, y: 0, z: 0 });
+        if (origin) {
+            ctx.fillStyle = "#ffffff";
+            ctx.beginPath(); ctx.arc(origin.x, origin.y, 6, 0, Math.PI * 2); ctx.fill();
+            ctx.strokeStyle = "#000000"; ctx.lineWidth = 2; ctx.stroke();
 
-        // Origin labels
-        ctx.fillStyle = "white";
-        ctx.font = "bold 12px Arial";
-        ctx.textAlign = "center";
-        ctx.fillText("(0,0,0)", origin.x, origin.y - 12);
+            // Origin labels
+            ctx.fillStyle = "white";
+            ctx.font = "bold 12px Arial";
+            ctx.textAlign = "center";
+            ctx.fillText("(0,0,0)", origin.x, origin.y - 12);
+        }
     }
 
     ctx.restore();

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -54,25 +54,27 @@ export function world3DToScreen(worldPos) {
     if (!r3d || !r3d.lastProjectionMatrix || !r3d.lastViewMatrix || !glm) return null;
 
     const canvas = r3d.canvas;
-    const worldVec = [worldPos.x, worldPos.y, (worldPos.z || 0), 1.0];
+    // Apply Y-Inversion to match Renderer3D mapping
+    const worldVec = glm.vec4.fromValues(worldPos.x, -worldPos.y, worldPos.z || 0, 1.0);
 
     const mvp = glm.mat4.create();
     glm.mat4.multiply(mvp, r3d.lastProjectionMatrix, r3d.lastViewMatrix);
 
-    const res = [0, 0, 0, 0];
-    // manual multiplication to get W correctly for clipping
-    for(let i=0; i<4; i++) {
-        res[i] = mvp[i]*worldVec[0] + mvp[i+4]*worldVec[1] + mvp[i+8]*worldVec[2] + mvp[i+12]*worldVec[3];
-    }
+    const clipPos = glm.vec4.create();
+    glm.vec4.transformMat4(clipPos, worldVec, mvp);
 
     // Near plane clipping
-    if (res[3] < 0.1) return null;
+    if (clipPos[3] < 0.1) return null;
 
-    const ndc = [res[0] / res[3], res[1] / res[3], res[2] / res[3]];
+    const ndc = [clipPos[0] / clipPos[3], clipPos[1] / clipPos[3], clipPos[2] / clipPos[3]];
+
+    // Ensure we use the correct viewport dimensions which might be different from clientWidth/Height during picking or resizing
+    const width = canvas.width;
+    const height = canvas.height;
 
     return {
-        x: (ndc[0] * 0.5 + 0.5) * canvas.width,
-        y: (1.0 - (ndc[1] * 0.5 + 0.5)) * canvas.height
+        x: (ndc[0] * 0.5 + 0.5) * width,
+        y: (1.0 - (ndc[1] * 0.5 + 0.5)) * height
     };
 }
 
@@ -810,11 +812,15 @@ export function initialize(dependencies) {
             case 'move-z':
                 {
                     if (is3D && glm) {
-                        const axis = dragState.handle === 'move-x' ? [1,0,0] : (dragState.handle === 'move-y' ? [0,1,0] : [0,0,1]);
+                        const isY = dragState.handle === 'move-y';
+                        const axis = dragState.handle === 'move-x' ? [1,0,0] : (isY ? [0,1,0] : [0,0,1]);
                         const q = glm.quat.create();
                         glm.quat.fromEuler(q, dragState.initialTransform.rotationX || 0, dragState.initialTransform.rotationY || 0, dragState.initialTransform.rotationZ || 0);
                         const worldAxis = glm.vec3.create();
                         glm.vec3.transformQuat(worldAxis, axis, q);
+
+                        // Invert world axis Y to match Renderer3D's internal mapping
+                        if (isY) worldAxis[1] *= -1;
 
                         const cam = renderer.camera;
                         const camQ = glm.quat.create();
@@ -827,19 +833,19 @@ export function initialize(dependencies) {
                         const screenDx = moveEvent.clientX - dragState.initialMousePos.x;
                         const screenDy = moveEvent.clientY - dragState.initialMousePos.y;
 
-                        // Project world axis onto camera right and up to see how it looks on screen
+                        // Project world axis onto camera right and up
                         const axisOnScreenX = glm.vec3.dot(worldAxis, camRight);
-                        const axisOnScreenY = -glm.vec3.dot(worldAxis, camUp); // Screen Y is inverted
+                        const axisOnScreenY = -glm.vec3.dot(worldAxis, camUp); // Screen Y is down
 
-                        // Drag strength relative to distance
-                        const dist = glm.vec3.distance([cam.x, cam.y, cam.z], [transform.x, transform.y, transform.z || 0]);
+                        const dist = glm.vec3.distance([cam.x, -cam.y, cam.z], [transform.x, -transform.y, transform.z || 0]);
                         const sensitivity = dist / 1000;
 
                         const moveAmount = (screenDx * axisOnScreenX + screenDy * axisOnScreenY) * sensitivity;
 
                         let nextPos = [dragState.initialTransform.x, dragState.initialTransform.y, dragState.initialTransform.z || 0];
+                        // Apply movement. If it's Y, we use the axis as is because worldAxis[1] is already inverted
                         nextPos[0] += worldAxis[0] * moveAmount;
-                        nextPos[1] += worldAxis[1] * moveAmount;
+                        nextPos[1] += (isY ? -worldAxis[1] : worldAxis[1]) * moveAmount;
                         nextPos[2] += worldAxis[2] * moveAmount;
 
                         if (snapEnabled) {
@@ -1740,11 +1746,18 @@ function handle3DCameraNavigation() {
     const isFlying = InputManager.getMouseButton(2);
 
     if (isFlying) {
-        // Prevent browser context menu during flight
-        window.addEventListener('contextmenu', e => e.preventDefault(), { once: true });
+        // Aggressively prevent browser context menu during flight
+        const preventer = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+        };
+        // Use capture phase to catch it before anything else
+        window.addEventListener('contextmenu', preventer, { capture: true, once: true });
+        dom.sceneCanvas.addEventListener('contextmenu', preventer, { capture: true, once: true });
+        if (dom.sceneCanvas3d) dom.sceneCanvas3d.addEventListener('contextmenu', preventer, { capture: true, once: true });
 
         // Speed adjustments for larger 3D scenes
-        const baseSpeed = 800; // Slightly faster for more responsive feel
+        const baseSpeed = 800;
         const speed = baseSpeed * (InputManager.getKey('Shift') ? 3.0 : 1.0) * dt;
         const rotSpeed = 0.2;
 
@@ -1760,26 +1773,27 @@ function handle3DCameraNavigation() {
 
         // Q/E: World-aligned vertical movement
         let verticalMove = 0;
-        if (InputManager.getKey('e')) verticalMove += 1; // Up
-        if (InputManager.getKey('q')) verticalMove -= 1; // Down
+        if (InputManager.getKey('e')) verticalMove += 1; // Up (GL space)
+        if (InputManager.getKey('q')) verticalMove -= 1; // Down (GL space)
 
         if (hasMove) {
             glm.vec3.normalize(moveDir, moveDir);
 
             const rotationQuat = glm.quat.create();
-            // Camera in CE uses X=Pitch, Y=Yaw
+            // Important: Handle Y-inversion in navigation math
             glm.quat.fromEuler(rotationQuat, cam.rotation.x, cam.rotation.y, 0);
 
             const rotatedDir = glm.vec3.create();
             glm.vec3.transformQuat(rotatedDir, moveDir, rotationQuat);
 
             cam.x += rotatedDir[0] * speed;
-            cam.y += rotatedDir[1] * speed;
+            // CE-Y is inverted relative to GL-Y
+            cam.y -= rotatedDir[1] * speed;
             cam.z += rotatedDir[2] * speed;
         }
 
-        // Apply Vertical Movement separately to keep it world-locked
-        cam.y += verticalMove * speed;
+        // Apply Vertical Movement (CE-Y inverted)
+        cam.y -= verticalMove * speed;
 
         // --- 2. Rotation (Mouse look) ---
         const delta = InputManager.getMouseDelta();
@@ -1826,7 +1840,8 @@ export function focusOnSelectedMateria() {
 
     let size = 50;
     if (meshRenderer) {
-        size = Math.max(Math.abs(transform.scale.x), Math.abs(transform.scale.y), Math.abs(transform.scale.z || 1)) * 2;
+        // Now using standardized size 1.0 primitives
+        size = Math.max(Math.abs(transform.scale.x), Math.abs(transform.scale.y), Math.abs(transform.scale.z || 1));
     } else {
         const dims = getMateriaDimensions(materia);
         size = Math.max(dims.width * Math.abs(transform.scale.x), dims.height * Math.abs(transform.scale.y));
@@ -1836,11 +1851,12 @@ export function focusOnSelectedMateria() {
         // Position camera at a distance relative to size
         const distance = Math.max(150, size * 3.0);
         cam.x = transform.x;
-        cam.y = transform.y + (size * 0.4);
+        // CE-Y negative is "above" in 3D pass
+        cam.y = transform.y - (size * 0.4);
         cam.z = (transform.z || 0) + distance;
 
         // Reset rotation to look at the object
-        cam.rotation.x = 10;
+        cam.rotation.x = 15; // Pitch down 15 degrees
         cam.rotation.y = 0;
     } else {
         cam.x = transform.x;
@@ -1863,15 +1879,6 @@ export function update() {
         // F key to focus
         if (InputManager.getKeyDown('f')) {
             focusOnSelectedMateria();
-        }
-
-        // Suppress browser context menu during right-click navigation
-        if (InputManager.getMouseButton(2)) {
-            const preventer = (e) => {
-                e.preventDefault();
-                window.removeEventListener('contextmenu', preventer);
-            };
-            window.addEventListener('contextmenu', preventer);
         }
     } else {
         handleEditorInteractions();
@@ -2364,6 +2371,11 @@ function check3DGizmoHit(canvasPos, materia) {
 function draw3DGizmos(materia) {
     const transform = materia.getComponent(Components.Transform);
     const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
+    const rotation = {
+        x: transform.rotationX || 0,
+        y: transform.rotationY || 0,
+        z: transform.rotationZ || 0
+    };
     const screenPos = world3DToScreen(center);
     if (!screenPos) return;
 
@@ -2376,12 +2388,12 @@ function draw3DGizmos(materia) {
 
     const meshRenderer = materia.getComponent(C3D.MeshRenderer3D);
     if (meshRenderer) {
-        const mult = 2; // Mesh is -1 to 1, so 2 units wide.
-        if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y, z: mult * transform.scale.z });
-        else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.y, transform.scale.z));
-        else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: mult * transform.scale.x, z: mult * transform.scale.z });
-        else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y });
-        else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.z), mult * transform.scale.y);
+        const scale = { x: transform.scale.x, y: transform.scale.y, z: transform.scale.z || 1 };
+        if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, scale, rotation);
+        else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, Math.max(scale.x, scale.y, scale.z) * 0.5, rotation);
+        else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: scale.x, z: scale.z }, rotation);
+        else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: scale.x, y: scale.y }, rotation);
+        else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, Math.max(scale.x, scale.z) * 0.25, scale.y, rotation);
     } else if (materia.getComponent(Components.Camera)) {
         drawCameraGizmos(renderer);
     }
@@ -2656,29 +2668,32 @@ function drawLineClipped(p1, p2, color, width = 1) {
     const mvp = glm.mat4.create();
     glm.mat4.multiply(mvp, r3d.lastProjectionMatrix, r3d.lastViewMatrix);
 
-    const project = (p) => {
-        const v = [p.x, p.y, p.z || 0, 1.0];
-        const res = [0, 0, 0, 0];
-        for(let i=0; i<4; i++) res[i] = mvp[i]*v[0] + mvp[i+4]*v[1] + mvp[i+8]*v[2] + mvp[i+12]*v[3];
-        return res;
-    };
+    // Apply Y-Inversion to match Renderer3D mapping
+    const v1 = glm.vec4.fromValues(p1.x, -p1.y, p1.z || 0, 1.0);
+    const v2 = glm.vec4.fromValues(p2.x, -p2.y, p2.z || 0, 1.0);
 
-    let v1 = project(p1), v2 = project(p2);
+    const c1 = glm.vec4.create();
+    const c2 = glm.vec4.create();
+    glm.vec4.transformMat4(c1, v1, mvp);
+    glm.vec4.transformMat4(c2, v2, mvp);
 
-    // Liang-Barsky-style clipping for W (near plane)
+    // Liang-Barsky-style clipping for Near Plane (W)
     const wNear = 0.1;
-    if (v1[3] < wNear && v2[3] < wNear) return;
+    if (c1[3] < wNear && c2[3] < wNear) return;
 
-    if (v1[3] < wNear) {
-        const t = (wNear - v1[3]) / (v2[3] - v1[3]);
-        for(let i=0; i<4; i++) v1[i] = v1[i] + t * (v2[i] - v1[i]);
-    } else if (v2[3] < wNear) {
-        const t = (wNear - v2[3]) / (v1[3] - v2[3]);
-        for(let i=0; i<4; i++) v2[i] = v2[i] + t * (v1[i] - v2[i]);
+    if (c1[3] < wNear) {
+        const t = (wNear - c1[3]) / (c2[3] - c1[3]);
+        glm.vec4.lerp(c1, c1, c2, t);
+    } else if (c2[3] < wNear) {
+        const t = (wNear - c2[3]) / (c1[3] - c2[3]);
+        glm.vec4.lerp(c2, c2, c1, t);
     }
 
-    const s1 = { x: (v1[0]/v1[3] * 0.5 + 0.5) * r3d.canvas.width, y: (1.0 - (v1[1]/v1[3] * 0.5 + 0.5)) * r3d.canvas.height };
-    const s2 = { x: (v2[0]/v2[3] * 0.5 + 0.5) * r3d.canvas.width, y: (1.0 - (v2[1]/v2[3] * 0.5 + 0.5)) * r3d.canvas.height };
+    const w = r3d.canvas.width;
+    const h = r3d.canvas.height;
+
+    const s1 = { x: (c1[0]/c1[3] * 0.5 + 0.5) * w, y: (1.0 - (c1[1]/c1[3] * 0.5 + 0.5)) * h };
+    const s2 = { x: (c2[0]/c2[3] * 0.5 + 0.5) * w, y: (1.0 - (c2[1]/c2[3] * 0.5 + 0.5)) * h };
 
     const { ctx } = renderer;
     ctx.strokeStyle = color;
@@ -2721,13 +2736,13 @@ function draw3DGrid() {
 
     // Main Axes (Infinite Origin Lines)
     if (prefs.showOriginAxes !== false) {
-        const axisLen = 100000;
+        const axisLen = 1000000;
         // X Axis (Red)
-        drawLineClipped({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 50, 50, 1.0)', 2);
+        drawLineClipped({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 70, 70, 0.8)', 1.5);
         // Y Axis (Green)
-        drawLineClipped({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(50, 255, 50, 1.0)', 2);
+        drawLineClipped({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(70, 255, 70, 0.8)', 1.5);
         // Z Axis (Blue)
-        drawLineClipped({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(50, 50, 255, 1.0)', 2);
+        drawLineClipped({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(70, 70, 255, 0.8)', 1.5);
 
         const origin = world3DToScreen({ x: 0, y: 0, z: 0 });
         if (origin) {

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -790,12 +790,11 @@ export function initialize(dependencies) {
         const config = getCurrentProjectConfig();
         const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
 
-        // In 3D, screen deltas are often more reliable than 2D-world-projection for 3D axes
-        const screenDx = moveEvent.clientX - lastMousePosition.x;
-        const screenDy = moveEvent.clientY - lastMousePosition.y;
-
+        // In 3D, we'll use a better projection for axes
         const totalDx = (currentMouseWorld.x - dragState.initialMouseWorld.x);
         const totalDy = (currentMouseWorld.y - dragState.initialMouseWorld.y);
+
+        const glm = window.glMatrix;
 
         const prefs = getPreferences ? getPreferences() : {};
         const snapEnabled = prefs.snapping;
@@ -807,59 +806,126 @@ export function initialize(dependencies) {
                 transform.y = dragState.initialTransform.y + totalDy;
                 break;
             case 'move-x':
-                {
-                    let nextX = is3D ? (dragState.initialTransform.x + (moveEvent.clientX - dragState.initialMousePos.x)) : (dragState.initialTransform.x + totalDx);
-                    if (snapEnabled) nextX = Math.round(nextX / snapSize) * snapSize;
-                    transform.x = nextX;
-                }
-                break;
             case 'move-y':
+            case 'move-z':
                 {
-                    // In 3D, Y is up, but screen Y is down.
-                    let nextY = is3D ? (dragState.initialTransform.y - (moveEvent.clientY - dragState.initialMousePos.y)) : (dragState.initialTransform.y + totalDy);
-                    if (snapEnabled) nextY = Math.round(nextY / snapSize) * snapSize;
-                    transform.y = nextY;
+                    if (is3D && glm) {
+                        const axis = dragState.handle === 'move-x' ? [1,0,0] : (dragState.handle === 'move-y' ? [0,1,0] : [0,0,1]);
+                        const q = glm.quat.create();
+                        glm.quat.fromEuler(q, dragState.initialTransform.rotationX || 0, dragState.initialTransform.rotationY || 0, dragState.initialTransform.rotationZ || 0);
+                        const worldAxis = glm.vec3.create();
+                        glm.vec3.transformQuat(worldAxis, axis, q);
+
+                        const cam = renderer.camera;
+                        const camQ = glm.quat.create();
+                        glm.quat.fromEuler(camQ, cam.rotation.x, cam.rotation.y, 0);
+                        const camRight = glm.vec3.create();
+                        glm.vec3.transformQuat(camRight, [1,0,0], camQ);
+                        const camUp = glm.vec3.create();
+                        glm.vec3.transformQuat(camUp, [0,1,0], camQ);
+
+                        const screenDx = moveEvent.clientX - dragState.initialMousePos.x;
+                        const screenDy = moveEvent.clientY - dragState.initialMousePos.y;
+
+                        // Project world axis onto camera right and up to see how it looks on screen
+                        const axisOnScreenX = glm.vec3.dot(worldAxis, camRight);
+                        const axisOnScreenY = -glm.vec3.dot(worldAxis, camUp); // Screen Y is inverted
+
+                        // Drag strength relative to distance
+                        const dist = glm.vec3.distance([cam.x, cam.y, cam.z], [transform.x, transform.y, transform.z || 0]);
+                        const sensitivity = dist / 1000;
+
+                        const moveAmount = (screenDx * axisOnScreenX + screenDy * axisOnScreenY) * sensitivity;
+
+                        let nextPos = [dragState.initialTransform.x, dragState.initialTransform.y, dragState.initialTransform.z || 0];
+                        nextPos[0] += worldAxis[0] * moveAmount;
+                        nextPos[1] += worldAxis[1] * moveAmount;
+                        nextPos[2] += worldAxis[2] * moveAmount;
+
+                        if (snapEnabled) {
+                            nextPos[0] = Math.round(nextPos[0] / snapSize) * snapSize;
+                            nextPos[1] = Math.round(nextPos[1] / snapSize) * snapSize;
+                            nextPos[2] = Math.round(nextPos[2] / snapSize) * snapSize;
+                        }
+
+                        transform.x = nextPos[0];
+                        transform.y = nextPos[1];
+                        transform.z = nextPos[2];
+                    } else {
+                        if (dragState.handle === 'move-x') transform.x = dragState.initialTransform.x + (snapEnabled ? Math.round(totalDx / snapSize) * snapSize : totalDx);
+                        if (dragState.handle === 'move-y') transform.y = dragState.initialTransform.y + (snapEnabled ? Math.round(totalDy / snapSize) * snapSize : totalDy);
+                    }
                 }
                 break;
             case 'move-xy':
                 {
-                    let nextX = dragState.initialTransform.x + totalDx;
-                    let nextY = dragState.initialTransform.y + totalDy;
-                    if (snapEnabled) {
-                        nextX = Math.round(nextX / snapSize) * snapSize;
-                        nextY = Math.round(nextY / snapSize) * snapSize;
+                    if (is3D && glm) {
+                        // In 3D, move object on a plane parallel to the camera view
+                        const cam = renderer.camera;
+                        const camQ = glm.quat.create();
+                        glm.quat.fromEuler(camQ, cam.rotation.x, cam.rotation.y, 0);
+                        const camRight = glm.vec3.create();
+                        glm.vec3.transformQuat(camRight, [1,0,0], camQ);
+                        const camUp = glm.vec3.create();
+                        glm.vec3.transformQuat(camUp, [0,1,0], camQ);
+
+                        const screenDxTotal = moveEvent.clientX - dragState.initialMousePos.x;
+                        const screenDyTotal = moveEvent.clientY - dragState.initialMousePos.y;
+
+                        const dist = glm.vec3.distance([cam.x, cam.y, cam.z], [transform.x, transform.y, transform.z || 0]);
+                        const sensitivity = dist / 1000;
+
+                        let nextPos = [dragState.initialTransform.x, dragState.initialTransform.y, dragState.initialTransform.z || 0];
+                        nextPos[0] += (camRight[0] * screenDxTotal - camUp[0] * screenDyTotal) * sensitivity;
+                        nextPos[1] += (camRight[1] * screenDxTotal - camUp[1] * screenDyTotal) * sensitivity;
+                        nextPos[2] += (camRight[2] * screenDxTotal - camUp[2] * screenDyTotal) * sensitivity;
+
+                        if (snapEnabled) {
+                            nextPos[0] = Math.round(nextPos[0] / snapSize) * snapSize;
+                            nextPos[1] = Math.round(nextPos[1] / snapSize) * snapSize;
+                            nextPos[2] = Math.round(nextPos[2] / snapSize) * snapSize;
+                        }
+
+                        transform.x = nextPos[0];
+                        transform.y = nextPos[1];
+                        transform.z = nextPos[2];
+                    } else {
+                        let nextX = dragState.initialTransform.x + totalDx;
+                        let nextY = dragState.initialTransform.y + totalDy;
+                        if (snapEnabled) {
+                            nextX = Math.round(nextX / snapSize) * snapSize;
+                            nextY = Math.round(nextY / snapSize) * snapSize;
+                        }
+                        transform.x = nextX;
+                        transform.y = nextY;
                     }
-                    transform.x = nextX;
-                    transform.y = nextY;
-                }
-                break;
-            case 'move-z':
-                {
-                    // In 3D, for Z movement, we also use the world delta logic but since mouse movement is on screen,
-                    // we can't easily map screen space to world Z in a generic way without raycasting.
-                    // However, for consistency with X/Y, we'll use the vertical screen delta as a world proxy.
-                    const dyPx = (moveEvent.clientY - lastMousePosition.y);
-                    let nextZ = (transform.z || 0) + dyPx;
-                    if (snapEnabled) nextZ = Math.round(nextZ / snapSize) * snapSize;
-                    transform.z = nextZ;
                 }
                 break;
             case 'scale-x':
-                transform.localScale = { ...transform.localScale, x: dragState.initialTransform.scale.x + totalDx / 50 };
-                break;
             case 'scale-y':
-                transform.localScale = { ...transform.localScale, y: dragState.initialTransform.scale.y - totalDy / 50 };
-                break;
             case 'scale-z':
-                transform.localScale = { ...transform.localScale, z: dragState.initialTransform.scale.z + (moveEvent.clientY - lastMousePosition.y) / 50 };
+                {
+                    const screenDx = moveEvent.clientX - dragState.initialMousePos.x;
+                    const screenDy = moveEvent.clientY - dragState.initialMousePos.y;
+                    const amount = (screenDx - screenDy) / 100;
+                    const newScale = { ...transform.localScale };
+                    if (dragState.handle === 'scale-x') newScale.x = Math.max(0.01, dragState.initialTransform.scale.x + amount);
+                    if (dragState.handle === 'scale-y') newScale.y = Math.max(0.01, dragState.initialTransform.scale.y + amount);
+                    if (dragState.handle === 'scale-z') newScale.z = Math.max(0.01, (dragState.initialTransform.scale.z || 1) + amount);
+                    transform.localScale = newScale;
+                }
                 break;
             case 'scale-all':
-                const avgScale = 1 + (totalDx - totalDy) / 100;
-                transform.localScale = {
-                    x: dragState.initialTransform.scale.x * avgScale,
-                    y: dragState.initialTransform.scale.y * avgScale,
-                    z: dragState.initialTransform.scale.z * avgScale
-                };
+                {
+                    const screenDxTotal = moveEvent.clientX - dragState.initialMousePos.x;
+                    const screenDyTotal = moveEvent.clientY - dragState.initialMousePos.y;
+                    const avgScaleFactor = 1 + (screenDxTotal - screenDyTotal) / 200;
+                    transform.localScale = {
+                        x: Math.max(0.01, dragState.initialTransform.scale.x * avgScaleFactor),
+                        y: Math.max(0.01, dragState.initialTransform.scale.y * avgScaleFactor),
+                        z: Math.max(0.01, (dragState.initialTransform.scale.z || 1) * avgScaleFactor)
+                    };
+                }
                 break;
             case 'camera-resize-tl': case 'camera-resize-tr': case 'camera-resize-bl': case 'camera-resize-br': {
                 const cam = dragState.materia.getComponent(Components.Camera);
@@ -1730,6 +1796,7 @@ function handle3DCameraNavigation() {
 
             // Constrain pitch to avoid flipping
             cam.rotation.x = Math.max(-89.9, Math.min(89.9, cam.rotation.x));
+            updateScene();
         }
 
         // --- 3. Cursor Feedback ---
@@ -1754,20 +1821,33 @@ export function focusOnSelectedMateria() {
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
 
+    const C3D = window.Components3D || Components3D;
+    const meshRenderer = C3D ? materia.getComponent(C3D.MeshRenderer3D) : null;
+
+    let size = 50;
+    if (meshRenderer) {
+        size = Math.max(Math.abs(transform.scale.x), Math.abs(transform.scale.y), Math.abs(transform.scale.z || 1)) * 2;
+    } else {
+        const dims = getMateriaDimensions(materia);
+        size = Math.max(dims.width * Math.abs(transform.scale.x), dims.height * Math.abs(transform.scale.y));
+    }
+
     if (is3D) {
-        // Position camera at a comfortable distance (e.g., 200 units) from the object
-        // and look at it.
-        const distance = 300;
+        // Position camera at a distance relative to size
+        const distance = Math.max(150, size * 3.0);
         cam.x = transform.x;
-        cam.y = transform.y + 100; // Slightly above
+        cam.y = transform.y + (size * 0.4);
         cam.z = (transform.z || 0) + distance;
-        // Looking down slightly
-        cam.rotation.x = 15;
+
+        // Reset rotation to look at the object
+        cam.rotation.x = 10;
         cam.rotation.y = 0;
     } else {
         cam.x = transform.x;
         cam.y = transform.y;
-        cam.zoom = 1.0;
+        // Adjust zoom to fit object
+        const targetZoom = Math.max(0.1, Math.min(2.0, 400 / (size || 1)));
+        cam.zoom = targetZoom;
     }
     updateScene();
 }
@@ -1779,8 +1859,19 @@ export function update() {
 
     if (is3D && !window.isGameRunning && getActiveView() === 'scene-content') {
         handle3DCameraNavigation();
+
+        // F key to focus
         if (InputManager.getKeyDown('f')) {
             focusOnSelectedMateria();
+        }
+
+        // Suppress browser context menu during right-click navigation
+        if (InputManager.getMouseButton(2)) {
+            const preventer = (e) => {
+                e.preventDefault();
+                window.removeEventListener('contextmenu', preventer);
+            };
+            window.addEventListener('contextmenu', preventer);
         }
     } else {
         handleEditorInteractions();
@@ -1885,6 +1976,7 @@ function drawCameraGizmos(renderer) {
         if (!transform) return;
 
         const isSelected = selectedMateria && selectedMateria.id === materia.id;
+        const glm = window.glMatrix;
 
         ctx.save();
         ctx.strokeStyle = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
@@ -1919,7 +2011,7 @@ function drawCameraGizmos(renderer) {
             }
 
             // --- Draw Interactive Handles (only for selected camera) ---
-            if (isSelected) {
+            if (isSelected && !is3D) {
                 ctx.fillStyle = 'rgba(255, 255, 0, 0.9)';
                 const handleSize = 8 / renderer.camera.effectiveZoom;
                 const halfHandle = handleSize / 2;
@@ -1937,23 +2029,37 @@ function drawCameraGizmos(renderer) {
                 });
             }
 
-        } else { // Perspective logic remains the same
+        } else if (is3D && glm) { // 3D Perspective Frustum
             const fovRad = cameraComponent.fov * Math.PI / 180;
             const near = cameraComponent.nearClipPlane;
-            const far = cameraComponent.farClipPlane;
-            const nearHalfHeight = Math.tan(fovRad / 2) * near;
-            const nearHalfWidth = nearHalfHeight * aspect;
-            const farHalfHeight = Math.tan(fovRad / 2) * far;
-            const farHalfWidth = farHalfHeight * aspect;
+            const far = Math.min(cameraComponent.farClipPlane, 1000); // Limit far for gizmo visibility
+            const nearH = Math.tan(fovRad / 2) * near;
+            const nearW = nearH * aspect;
+            const farH = Math.tan(fovRad / 2) * far;
+            const farW = farH * aspect;
 
-            ctx.beginPath();
-            ctx.moveTo(-nearHalfWidth, -nearHalfHeight); ctx.lineTo(nearHalfWidth, -nearHalfHeight); ctx.lineTo(nearHalfWidth, nearHalfHeight); ctx.lineTo(-nearHalfWidth, nearHalfHeight); ctx.closePath();
-            ctx.moveTo(-farHalfWidth, -farHalfHeight); ctx.lineTo(farHalfWidth, -farHalfHeight); ctx.lineTo(farHalfWidth, farHalfHeight); ctx.lineTo(-farHalfWidth, farHalfHeight); ctx.closePath();
-            ctx.moveTo(-nearHalfWidth, -nearHalfHeight); ctx.lineTo(-farHalfWidth, -farHalfHeight);
-            ctx.moveTo(nearHalfWidth, -nearHalfHeight); ctx.lineTo(farHalfWidth, -farHalfHeight);
-            ctx.moveTo(nearHalfWidth, nearHalfHeight); ctx.lineTo(farHalfWidth, farHalfHeight);
-            ctx.moveTo(-nearHalfWidth, nearHalfHeight); ctx.lineTo(-farHalfWidth, farHalfHeight);
-            ctx.stroke();
+            const q = glm.quat.create();
+            glm.quat.fromEuler(q, transform.rotationX || 0, transform.rotationY || 0, transform.rotationZ || 0);
+
+            const project = (lx, ly, lz) => {
+                const worldPos = glm.vec3.create();
+                glm.vec3.transformQuat(worldPos, [lx, ly, -lz], q); // Cameras look towards -Z in many conventions, check ours
+                return world3DToScreen({ x: transform.x + worldPos[0], y: transform.y + worldPos[1], z: (transform.z || 0) + worldPos[2] });
+            };
+
+            const n1 = project(-nearW, nearH, near), n2 = project(nearW, nearH, near), n3 = project(nearW, -nearH, near), n4 = project(-nearW, -nearH, near);
+            const f1 = project(-farW, farH, far), f2 = project(farW, farH, far), f3 = project(farW, -farH, far), f4 = project(-farW, -farH, far);
+
+            const drawLine = (p1, p2) => {
+                if (p1 && p2) { ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y); ctx.stroke(); }
+            };
+
+            // Near plane
+            drawLine(n1, n2); drawLine(n2, n3); drawLine(n3, n4); drawLine(n4, n1);
+            // Far plane
+            drawLine(f1, f2); drawLine(f2, f3); drawLine(f3, f4); drawLine(f4, f1);
+            // Connecting lines
+            drawLine(n1, f1); drawLine(n2, f2); drawLine(n3, f3); drawLine(n4, f4);
         }
 
         ctx.restore();
@@ -2228,8 +2334,14 @@ function check3DGizmoHit(canvasPos, materia) {
     const hitRadius = 20;
     const gizmoLen = 80;
 
-    const checkHandle = (worldAxis, name) => {
-        const axisEnd = { x: center.x + worldAxis.x * gizmoLen, y: center.y + worldAxis.y * gizmoLen, z: center.z + worldAxis.z * gizmoLen };
+    const glm = window.glMatrix;
+    const q = glm.quat.create();
+    glm.quat.fromEuler(q, transform.rotationX || 0, transform.rotationY || 0, transform.rotationZ || 0);
+
+    const checkHandle = (localAxis, name) => {
+        const worldAxis = glm.vec3.create();
+        glm.vec3.transformQuat(worldAxis, [localAxis.x, localAxis.y, localAxis.z], q);
+        const axisEnd = { x: center.x + worldAxis[0] * gizmoLen, y: center.y + worldAxis[1] * gizmoLen, z: center.z + worldAxis[2] * gizmoLen };
         const screenEnd = world3DToScreen(axisEnd);
         if (!screenEnd) return false;
         const dx = canvasPos.x - screenEnd.x;
@@ -2240,11 +2352,11 @@ function check3DGizmoHit(canvasPos, materia) {
     if (activeTool === 'move' || activeTool === 'universal' || activeTool === 'scale') {
         const dx = canvasPos.x - screenPos.x;
         const dy = canvasPos.y - screenPos.y;
-        if (Math.hypot(dx, dy) < hitRadius) return activeTool === 'scale' ? 'scale-all' : 'move-xy';
+        if (Math.hypot(dx, dy) < 15) return activeTool === 'scale' ? 'scale-all' : 'move-xy';
 
-        if (checkHandle({x:1, y:0, z:0}, activeTool === 'scale' ? 'scale-x' : 'move-x')) return activeTool === 'scale' ? 'scale-x' : 'move-x';
-        if (checkHandle({x:0, y:1, z:0}, activeTool === 'scale' ? 'scale-y' : 'move-y')) return activeTool === 'scale' ? 'scale-y' : 'move-y';
-        if (checkHandle({x:0, y:0, z:1}, activeTool === 'scale' ? 'scale-z' : 'move-z')) return activeTool === 'scale' ? 'scale-z' : 'move-z';
+        if (checkHandle({x:1, y:0, z:0}, 'X')) return activeTool === 'scale' ? 'scale-x' : 'move-x';
+        if (checkHandle({x:0, y:1, z:0}, 'Y')) return activeTool === 'scale' ? 'scale-y' : 'move-y';
+        if (checkHandle({x:0, y:0, z:1}, 'Z')) return activeTool === 'scale' ? 'scale-z' : 'move-z';
     }
     return null;
 }
@@ -2264,19 +2376,28 @@ function draw3DGizmos(materia) {
 
     const meshRenderer = materia.getComponent(C3D.MeshRenderer3D);
     if (meshRenderer) {
-        const mult = 2;
+        const mult = 2; // Mesh is -1 to 1, so 2 units wide.
         if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y, z: mult * transform.scale.z });
         else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.y, transform.scale.z));
         else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: mult * transform.scale.x, z: mult * transform.scale.z });
         else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: mult * transform.scale.x, y: mult * transform.scale.y });
         else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, (mult/2) * Math.max(transform.scale.x, transform.scale.z), mult * transform.scale.y);
+    } else if (materia.getComponent(Components.Camera)) {
+        drawCameraGizmos(renderer);
     }
 
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    const drawAxis = (axis, color, name) => {
-        const endPos = { x: center.x + axis.x * GIZMO_SIZE, y: center.y + axis.y * GIZMO_SIZE, z: center.z + axis.z * GIZMO_SIZE };
+    const glm = window.glMatrix;
+    const q = glm.quat.create();
+    glm.quat.fromEuler(q, transform.rotationX || 0, transform.rotationY || 0, transform.rotationZ || 0);
+
+    const drawAxis = (localAxis, color) => {
+        const worldAxis = glm.vec3.create();
+        glm.vec3.transformQuat(worldAxis, [localAxis.x, localAxis.y, localAxis.z], q);
+
+        const endPos = { x: center.x + worldAxis[0] * GIZMO_SIZE, y: center.y + worldAxis[1] * GIZMO_SIZE, z: center.z + worldAxis[2] * GIZMO_SIZE };
         const endScreen = world3DToScreen(endPos);
         if (!endScreen) return;
 
@@ -2306,13 +2427,13 @@ function draw3DGizmos(materia) {
     };
 
     if (activeTool === 'move' || activeTool === 'universal' || activeTool === 'scale') {
-        drawAxis({x:1,y:0,z:0}, '#ff4444', 'X');
-        drawAxis({x:0,y:1,z:0}, '#44ff44', 'Y');
-        drawAxis({x:0,y:0,z:1}, '#4444ff', 'Z');
+        drawAxis({x:1,y:0,z:0}, '#ff4444'); // X (Red)
+        drawAxis({x:0,y:1,z:0}, '#44ff44'); // Y (Green)
+        drawAxis({x:0,y:0,z:1}, '#4444ff'); // Z (Blue)
 
         // Center handle
         ctx.fillStyle = activeTool === 'scale' ? '#ffffff' : 'rgba(255, 255, 255, 0.5)';
-        ctx.beginPath(); ctx.arc(screenPos.x, screenPos.y, 6, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(screenPos.x, screenPos.y, 8, 0, Math.PI * 2); ctx.fill();
         ctx.strokeStyle = '#000'; ctx.lineWidth = 1; ctx.stroke();
     }
 
@@ -2354,6 +2475,10 @@ export function drawOverlay() {
     // Frustum Visualizer for Optimization Mode
     if (config.optiCameraCulling) {
         drawFrustumCullingGizmos();
+    }
+
+    if (is3D) {
+        draw3DGrid();
     }
 
     // Draw Icons (Audio, Camera, etc)
@@ -2523,91 +2648,93 @@ function drawRaycastGizmos() {
     ctx.restore();
 }
 
+function drawLineClipped(p1, p2, color, width = 1) {
+    const r3d = window._Renderer3D;
+    const glm = window.glMatrix;
+    if (!r3d || !r3d.lastProjectionMatrix || !r3d.lastViewMatrix || !glm) return;
+
+    const mvp = glm.mat4.create();
+    glm.mat4.multiply(mvp, r3d.lastProjectionMatrix, r3d.lastViewMatrix);
+
+    const project = (p) => {
+        const v = [p.x, p.y, p.z || 0, 1.0];
+        const res = [0, 0, 0, 0];
+        for(let i=0; i<4; i++) res[i] = mvp[i]*v[0] + mvp[i+4]*v[1] + mvp[i+8]*v[2] + mvp[i+12]*v[3];
+        return res;
+    };
+
+    let v1 = project(p1), v2 = project(p2);
+
+    // Liang-Barsky-style clipping for W (near plane)
+    const wNear = 0.1;
+    if (v1[3] < wNear && v2[3] < wNear) return;
+
+    if (v1[3] < wNear) {
+        const t = (wNear - v1[3]) / (v2[3] - v1[3]);
+        for(let i=0; i<4; i++) v1[i] = v1[i] + t * (v2[i] - v1[i]);
+    } else if (v2[3] < wNear) {
+        const t = (wNear - v2[3]) / (v1[3] - v2[3]);
+        for(let i=0; i<4; i++) v2[i] = v2[i] + t * (v1[i] - v2[i]);
+    }
+
+    const s1 = { x: (v1[0]/v1[3] * 0.5 + 0.5) * r3d.canvas.width, y: (1.0 - (v1[1]/v1[3] * 0.5 + 0.5)) * r3d.canvas.height };
+    const s2 = { x: (v2[0]/v2[3] * 0.5 + 0.5) * r3d.canvas.width, y: (1.0 - (v2[1]/v2[3] * 0.5 + 0.5)) * r3d.canvas.height };
+
+    const { ctx } = renderer;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.beginPath();
+    ctx.moveTo(s1.x, s1.y);
+    ctx.lineTo(s2.x, s2.y);
+    ctx.stroke();
+}
+
 function draw3DGrid() {
     const prefs = getPreferences();
     if (!prefs.showSceneGrid) return;
 
-    const { ctx, camera, canvas } = renderer;
+    const { ctx, camera } = renderer;
     if (!camera) return;
 
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0); // Screen Space
 
-    // --- Adaptive 3D Grid ---
-    // Calculate distance to origin or grid plane to adjust scale
+    // --- Adaptive 3D Grid on XZ plane (Floor) ---
     const dist = Math.abs(camera.y) || 500;
     const magnitude = Math.pow(10, Math.floor(Math.log10(dist / 5)));
     const step = Math.max(1, magnitude);
 
-    const gridRange = 60; // Increased range
+    const gridRange = 50;
     const gridColor = 'rgba(255, 255, 255, 0.1)';
     const majorGridColor = 'rgba(255, 255, 255, 0.3)';
 
-    // Infinite effect: snapped to steps on XY plane
     const snapX = Math.floor(camera.x / step) * step;
-    const snapY = Math.floor(camera.y / step) * step;
+    const snapZ = Math.floor(camera.z / step) * step;
 
     const startX = snapX - (gridRange * step);
     const endX = snapX + (gridRange * step);
-    const startY = snapY - (gridRange * step);
-    const endY = snapY + (gridRange * step);
+    const startZ = snapZ - (gridRange * step);
+    const endZ = snapZ + (gridRange * step);
 
-    ctx.lineWidth = 1;
-
-    // Helper for clipped line drawing
-    const drawLine3D = (p1World, p2World, color) => {
-        const p1 = world3DToScreen(p1World);
-        const p2 = world3DToScreen(p2World);
-        if (p1 && p2) {
-            ctx.strokeStyle = color;
-            ctx.beginPath();
-            ctx.moveTo(p1.x, p1.y);
-            ctx.lineTo(p2.x, p2.y);
-            ctx.stroke();
-        }
-    };
-
-    // Vertical grid lines (varying Y)
-    for (let x = startX; x <= endX; x += step) {
-        const isMajor = Math.round(x / step) % 10 === 0;
-        const isOrigin = Math.abs(x) < 0.01;
-        if (isOrigin) continue;
-        drawLine3D({ x, y: startY, z: 0 }, { x, y: endY, z: 0 }, isMajor ? majorGridColor : gridColor);
-    }
-
-    // Horizontal grid lines (varying X)
-    for (let y = startY; y <= endY; y += step) {
-        const isMajor = Math.round(y / step) % 10 === 0;
-        const isOrigin = Math.abs(y) < 0.01;
-        if (isOrigin) continue;
-        drawLine3D({ x: startX, y, z: 0 }, { x: endX, y, z: 0 }, isMajor ? majorGridColor : gridColor);
-    }
+    // We skip floor grid lines in 2D overlay because Renderer3D already draws an infinite depth-tested grid.
+    // This prevents Z-fighting and ensures objects correctly occlude the grid.
 
     // Main Axes (Infinite Origin Lines)
     if (prefs.showOriginAxes !== false) {
-        ctx.lineWidth = 2;
-        const axisLen = 1000000; // Large enough to look infinite
-
+        const axisLen = 100000;
         // X Axis (Red)
-        drawLine3D({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 50, 50, 0.8)');
-
+        drawLineClipped({ x: -axisLen, y: 0, z: 0 }, { x: axisLen, y: 0, z: 0 }, 'rgba(255, 50, 50, 1.0)', 2);
         // Y Axis (Green)
-        drawLine3D({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(50, 255, 50, 0.8)');
-
+        drawLineClipped({ x: 0, y: -axisLen, z: 0 }, { x: 0, y: axisLen, z: 0 }, 'rgba(50, 255, 50, 1.0)', 2);
         // Z Axis (Blue)
-        drawLine3D({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(50, 50, 255, 0.8)');
+        drawLineClipped({ x: 0, y: 0, z: -axisLen }, { x: 0, y: 0, z: axisLen }, 'rgba(50, 50, 255, 1.0)', 2);
 
-        // Center Crosshair (Origin Point)
         const origin = world3DToScreen({ x: 0, y: 0, z: 0 });
         if (origin) {
             ctx.fillStyle = "#ffffff";
             ctx.beginPath(); ctx.arc(origin.x, origin.y, 6, 0, Math.PI * 2); ctx.fill();
             ctx.strokeStyle = "#000000"; ctx.lineWidth = 2; ctx.stroke();
-
-            // Origin labels
-            ctx.fillStyle = "white";
-            ctx.font = "bold 12px Arial";
-            ctx.textAlign = "center";
+            ctx.fillStyle = "white"; ctx.font = "bold 12px Arial"; ctx.textAlign = "center";
             ctx.fillText("(0,0,0)", origin.x, origin.y - 12);
         }
     }

--- a/js/editor/ui/InspectorWindow.js
+++ b/js/editor/ui/InspectorWindow.js
@@ -582,7 +582,7 @@ async function handleInspectorChange(e) {
         const propPath = e.target.dataset.prop;
         const value = e.target.value;
 
-        const ComponentClass = Components[componentName] || getComponent(componentName);
+        const ComponentClass = Components[componentName] || (window.Components3D ? window.Components3D[componentName] : null) || getComponent(componentName);
         if (ComponentClass) {
             const component = selectedMateria.getComponent(ComponentClass);
             if (component) {
@@ -4169,7 +4169,7 @@ async function updateInspectorForMateria(selectedMateria) {
                     <div class="inspector-group">
                         <div class="prop-row-multi">
                             <label data-i18n="MESH_TYPE">Tipo de Malla</label>
-                            <select class="prop-input" data-component="MeshRenderer3D" data-prop="meshType">
+                            <select class="prop-input inspector-re-render" data-component="MeshRenderer3D" data-prop="meshType">
                                 <option value="Cube" ${ley.meshType === 'Cube' ? 'selected' : ''}>Cubo</option>
                                 <option value="Sphere" ${ley.meshType === 'Sphere' ? 'selected' : ''}>Esfera</option>
                                 <option value="Plane" ${ley.meshType === 'Plane' ? 'selected' : ''}>Plano</option>

--- a/js/editor/ui/InspectorWindow.js
+++ b/js/editor/ui/InspectorWindow.js
@@ -403,7 +403,7 @@ function handleInspectorInput(e) {
         return;
     }
 
-    const ComponentClass = Components[componentName];
+    const ComponentClass = Components[componentName] || (window.Components3D ? window.Components3D[componentName] : null);
     if (!ComponentClass) return;
 
     const component = selectedMateria.getComponent(ComponentClass);

--- a/js/editor/ui/InspectorWindow.js
+++ b/js/editor/ui/InspectorWindow.js
@@ -595,7 +595,10 @@ async function handleInspectorChange(e) {
 
     if (needsUpdate) {
         // Use a slight delay to allow the value to update before re-rendering
-        setTimeout(updateInspector, 0);
+        setTimeout(() => {
+            updateInspector();
+            if (updateSceneCallback) updateSceneCallback();
+        }, 0);
     }
 }
 

--- a/js/editor/ui/PreferencesWindow.js
+++ b/js/editor/ui/PreferencesWindow.js
@@ -22,6 +22,7 @@ const defaultPrefs = {
     autosaveInterval: 30,
     scriptLang: 'ces',
     showSceneGrid: true,
+    showOriginAxes: true,
     snapping: false,
     gridSize: 25,
     zoomSpeed: 1.1,
@@ -153,6 +154,7 @@ async function savePreferences() {
     currentPreferences.autosaveInterval = _dom.prefsAutosaveInterval.value;
     currentPreferences.scriptLang = _dom.prefsScriptLang.value;
     currentPreferences.showSceneGrid = _dom.prefsShowSceneGrid.checked;
+    currentPreferences.showOriginAxes = _dom.prefsShowOriginAxes.checked;
     currentPreferences.snapping = _dom.prefsSnappingToggle.checked;
     currentPreferences.gridSize = _dom.prefsSnappingGridSize.value;
     currentPreferences.zoomSpeed = parseFloat(_dom.prefsZoomSpeed.value) || 1.1;
@@ -227,6 +229,7 @@ function loadPreferences() {
     if (_dom.prefsAutosaveInterval) _dom.prefsAutosaveInterval.value = currentPreferences.autosaveInterval;
     if (_dom.prefsScriptLang) _dom.prefsScriptLang.value = currentPreferences.scriptLang;
     if (_dom.prefsShowSceneGrid) _dom.prefsShowSceneGrid.checked = currentPreferences.showSceneGrid;
+    if (_dom.prefsShowOriginAxes) _dom.prefsShowOriginAxes.checked = currentPreferences.showOriginAxes;
     if (_dom.prefsSnappingToggle) _dom.prefsSnappingToggle.checked = currentPreferences.snapping;
     if (_dom.prefsSnappingGridSize) _dom.prefsSnappingGridSize.value = currentPreferences.gridSize;
     if (_dom.prefsZoomSpeed) _dom.prefsZoomSpeed.value = currentPreferences.zoomSpeed;
@@ -257,6 +260,14 @@ function loadPreferences() {
             _dom.prefsAutosaveIntervalGroup.classList.remove('hidden');
         } else {
             _dom.prefsAutosaveIntervalGroup.classList.add('hidden');
+        }
+    }
+
+    if (_dom.prefsSnappingToggle) {
+        if (_dom.prefsSnappingToggle.checked) {
+            _dom.prefsSnappingGridSizeGroup.classList.remove('hidden');
+        } else {
+            _dom.prefsSnappingGridSizeGroup.classList.add('hidden');
         }
     }
 

--- a/js/engine/Gizmos.js
+++ b/js/engine/Gizmos.js
@@ -7,21 +7,29 @@ export const Gizmos = {
     /**
      * Draws a wireframe cube in 3D space.
      */
-    drawWireCube(ctx, center, size, color = 'rgba(0, 255, 255, 0.8)') {
+    drawWireCube(ctx, center, size, rotation = {x:0, y:0, z:0}, color = 'rgba(0, 255, 255, 0.8)') {
+        const glm = window.glMatrix;
         const hw = size.x / 2;
         const hh = size.y / 2;
         const hd = size.z / 2;
 
         const points = [
-            { x: -hw, y: -hh, z: -hd }, { x: hw, y: -hh, z: -hd }, { x: hw, y: hh, z: -hd }, { x: -hw, y: hh, z: -hd },
-            { x: -hw, y: -hh, z: hd }, { x: hw, y: -hh, z: hd }, { x: hw, y: hh, z: hd }, { x: -hw, y: hh, z: hd }
+            [ -hw, -hh, -hd ], [ hw, -hh, -hd ], [ hw, hh, -hd ], [ -hw, hh, -hd ],
+            [ -hw, -hh, hd ], [ hw, -hh, hd ], [ hw, hh, hd ], [ -hw, hh, hd ]
         ];
 
-        const screenPoints = points.map(p => world3DToScreen({
-            x: center.x + p.x,
-            y: center.y + p.y,
-            z: (center.z || 0) + p.z
-        }));
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
+
+        const screenPoints = points.map(p => {
+            const rotated = glm.vec3.create();
+            glm.vec3.transformQuat(rotated, p, q);
+            return world3DToScreen({
+                x: center.x + rotated[0],
+                y: center.y - rotated[1], // World Y is handled as inverted in world3DToScreen
+                z: (center.z || 0) + rotated[2]
+            });
+        });
 
         if (screenPoints.some(p => p === null)) return;
 
@@ -52,29 +60,35 @@ export const Gizmos = {
     /**
      * Draws a wireframe sphere in 3D space using 3 rings.
      */
-    drawWireSphere(ctx, center, radius, color = 'rgba(0, 255, 255, 0.8)') {
+    drawWireSphere(ctx, center, radius, rotation = {x:0, y:0, z:0}, color = 'rgba(0, 255, 255, 0.8)') {
+        const glm = window.glMatrix;
         const segments = 16;
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
 
         const drawRing = (axis) => {
             ctx.beginPath();
             for (let i = 0; i <= segments; i++) {
                 const angle = (i / segments) * Math.PI * 2;
-                let pt = { x: 0, y: 0, z: 0 };
+                let pt = [0, 0, 0];
                 if (axis === 'xy') {
-                    pt.x = Math.cos(angle) * radius;
-                    pt.y = Math.sin(angle) * radius;
+                    pt[0] = Math.cos(angle) * radius;
+                    pt[1] = Math.sin(angle) * radius;
                 } else if (axis === 'xz') {
-                    pt.x = Math.cos(angle) * radius;
-                    pt.z = Math.sin(angle) * radius;
+                    pt[0] = Math.cos(angle) * radius;
+                    pt[2] = Math.sin(angle) * radius;
                 } else {
-                    pt.y = Math.cos(angle) * radius;
-                    pt.z = Math.sin(angle) * radius;
+                    pt[1] = Math.cos(angle) * radius;
+                    pt[2] = Math.sin(angle) * radius;
                 }
 
+                const rotated = glm.vec3.create();
+                glm.vec3.transformQuat(rotated, pt, q);
+
                 const screen = world3DToScreen({
-                    x: center.x + pt.x,
-                    y: center.y + pt.y,
-                    z: (center.z || 0) + pt.z
+                    x: center.x + rotated[0],
+                    y: center.y - rotated[1],
+                    z: (center.z || 0) + rotated[2]
                 });
                 if (screen) {
                     if (i === 0) ctx.moveTo(screen.x, screen.y);
@@ -94,21 +108,29 @@ export const Gizmos = {
     /**
      * Draws a wireframe triangle in 3D.
      */
-    drawWireTriangle(ctx, center, size, color = 'rgba(0, 255, 255, 0.8)') {
+    drawWireTriangle(ctx, center, size, rotation = {x:0, y:0, z:0}, color = 'rgba(0, 255, 255, 0.8)') {
+        const glm = window.glMatrix;
         const hw = size.x / 2;
         const hh = size.y / 2;
 
         const points = [
-            { x: 0, y: hh, z: 0 },
-            { x: -hw, y: -hh, z: 0 },
-            { x: hw, y: -hh, z: 0 }
+            [ 0, hh, 0 ],
+            [ -hw, -hh, 0 ],
+            [ hw, -hh, 0 ]
         ];
 
-        const screenPoints = points.map(p => world3DToScreen({
-            x: center.x + p.x,
-            y: center.y + p.y,
-            z: (center.z || 0) + p.z
-        }));
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
+
+        const screenPoints = points.map(p => {
+            const rotated = glm.vec3.create();
+            glm.vec3.transformQuat(rotated, p, q);
+            return world3DToScreen({
+                x: center.x + rotated[0],
+                y: center.y - rotated[1],
+                z: (center.z || 0) + rotated[2]
+            });
+        });
 
         if (screenPoints.some(p => p === null)) return;
 
@@ -125,22 +147,30 @@ export const Gizmos = {
     /**
      * Draws a wireframe plane in 3D.
      */
-    drawWirePlane(ctx, center, size, color = 'rgba(255, 255, 255, 0.5)') {
+    drawWirePlane(ctx, center, size, rotation = {x:0, y:0, z:0}, color = 'rgba(255, 255, 255, 0.5)') {
+        const glm = window.glMatrix;
         const hw = size.x / 2;
         const hd = size.z / 2;
 
         const points = [
-            { x: -hw, y: 0, z: -hd },
-            { x: hw, y: 0, z: -hd },
-            { x: hw, y: 0, z: hd },
-            { x: -hw, y: 0, z: hd }
+            [ -hw, 0, -hd ],
+            [ hw, 0, -hd ],
+            [ hw, 0, hd ],
+            [ -hw, 0, hd ]
         ];
 
-        const screenPoints = points.map(p => world3DToScreen({
-            x: center.x + p.x,
-            y: center.y,
-            z: (center.z || 0) + p.z
-        }));
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
+
+        const screenPoints = points.map(p => {
+            const rotated = glm.vec3.create();
+            glm.vec3.transformQuat(rotated, p, q);
+            return world3DToScreen({
+                x: center.x + rotated[0],
+                y: center.y - rotated[1],
+                z: (center.z || 0) + rotated[2]
+            });
+        });
 
         if (screenPoints.some(p => p === null)) return;
 
@@ -158,15 +188,24 @@ export const Gizmos = {
     /**
      * Draws a wireframe capsule in 3D.
      */
-    drawWireCapsule(ctx, center, radius, height, color = 'rgba(0, 255, 255, 0.8)') {
+    drawWireCapsule(ctx, center, radius, height, rotation = {x:0, y:0, z:0}, color = 'rgba(0, 255, 255, 0.8)') {
+        const glm = window.glMatrix;
         const hh = height / 2;
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
 
         // Draw vertical lines
         const drawLine = (lx, lz) => {
-            const p1 = world3DToScreen({ x: center.x + lx, y: center.y + hh, z: (center.z || 0) + lz });
-            const p2 = world3DToScreen({ x: center.x + lx, y: center.y - hh, z: (center.z || 0) + lz });
-            if (p1 && p2) {
-                ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y); ctx.stroke();
+            const p1 = [lx, hh, lz];
+            const p2 = [lx, -hh, lz];
+            const r1 = glm.vec3.create(), r2 = glm.vec3.create();
+            glm.vec3.transformQuat(r1, p1, q);
+            glm.vec3.transformQuat(r2, p2, q);
+
+            const s1 = world3DToScreen({ x: center.x + r1[0], y: center.y - r1[1], z: (center.z || 0) + r1[2] });
+            const s2 = world3DToScreen({ x: center.x + r2[0], y: center.y - r2[1], z: (center.z || 0) + r2[2] });
+            if (s1 && s2) {
+                ctx.beginPath(); ctx.moveTo(s1.x, s1.y); ctx.lineTo(s2.x, s2.y); ctx.stroke();
             }
         };
 
@@ -174,9 +213,14 @@ export const Gizmos = {
         ctx.lineWidth = 1;
         drawLine(radius, 0); drawLine(-radius, 0); drawLine(0, radius); drawLine(0, -radius);
 
-        // Draw top and bottom spheres (half)
-        this.drawWireSphere(ctx, { x: center.x, y: center.y + hh, z: center.z }, radius, color);
-        this.drawWireSphere(ctx, { x: center.x, y: center.y - hh, z: center.z }, radius, color);
+        // Draw top and bottom spheres (half) - these should ideally be hemi-spheres
+        const topCenter = glm.vec3.create();
+        glm.vec3.transformQuat(topCenter, [0, hh, 0], q);
+        this.drawWireSphere(ctx, { x: center.x + topCenter[0], y: center.y + topCenter[1], z: (center.z || 0) + topCenter[2] }, radius, rotation, color);
+
+        const bottomCenter = glm.vec3.create();
+        glm.vec3.transformQuat(bottomCenter, [0, -hh, 0], q);
+        this.drawWireSphere(ctx, { x: center.x + bottomCenter[0], y: center.y + bottomCenter[1], z: (center.z || 0) + bottomCenter[2] }, radius, rotation, color);
     },
 
     /**

--- a/js/engine/Input.js
+++ b/js/engine/Input.js
@@ -500,6 +500,10 @@ class InputManager {
         this._mouseButtons.clear();
         this._keysDown.clear();
         this._buttonsDown.clear();
+        this._buttonsUp.clear();
+        this._keysUp.clear();
+        this._mouseDelta.x = 0;
+        this._mouseDelta.y = 0;
         console.log('[InputManager] Focus lost: All inputs released.');
     }
 

--- a/js/engine/Input.js
+++ b/js/engine/Input.js
@@ -180,6 +180,8 @@ class InputManager {
         targetWindow.addEventListener('keydown', this._onKeyDown.bind(this));
         targetWindow.addEventListener('keyup', this._onKeyUp.bind(this));
         targetWindow.addEventListener('wheel', this._onWheel.bind(this), { passive: false });
+        targetWindow.addEventListener('blur', this._onBlur.bind(this));
+        targetWindow.addEventListener('focus', this._onBlur.bind(this));
 
         // Listen for mouse events on the window to ensure we catch releases outside the canvas
         targetWindow.addEventListener('mousedown', this._onWindowMouseDown.bind(this));

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -433,90 +433,122 @@ export class Renderer3D {
     initBuffers() {
         const gl = this.gl;
 
+        const createMesh = (pos, norm, idx, uv) => {
+            const mesh = {
+                pos: gl.createBuffer(),
+                norm: gl.createBuffer(),
+                idx: gl.createBuffer(),
+                uv: uv ? gl.createBuffer() : null,
+                count: idx.length
+            };
+            gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
+            gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(pos), gl.STATIC_DRAW);
+            gl.bindBuffer(gl.ARRAY_BUFFER, mesh.norm);
+            gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(norm), gl.STATIC_DRAW);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+            gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(idx), gl.STATIC_DRAW);
+            if (uv) {
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
+                gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(uv), gl.STATIC_DRAW);
+            }
+            return mesh;
+        };
+
         // Fullscreen Quad for Sky and Grid
-        const quadPositions = [
-            -1.0,  1.0,  0.0,
-             1.0,  1.0,  0.0,
-            -1.0, -1.0,  0.0,
-             1.0, -1.0,  0.0,
-        ];
+        const quadPositions = [-1,1,0, 1,1,0, -1,-1,0, 1,-1,0];
         this.skyBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, this.skyBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(quadPositions), gl.STATIC_DRAW);
 
-        // Basic Plane (for 2D sprites in 3D)
-        const planePositions = [
-            -0.5, -0.5,  0.0,
-             0.5, -0.5,  0.0,
-             0.5,  0.5,  0.0,
-            -0.5,  0.5,  0.0,
-        ];
-        this.planeBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(planePositions), gl.STATIC_DRAW);
+        // Cube Mesh (2x2x2)
+        this.meshCube = createMesh(
+            [
+                -1,-1,1, 1,-1,1, 1,1,1, -1,1,1, -1,-1,-1, -1,1,-1, 1,1,-1, 1,-1,-1,
+                -1,1,-1, -1,1,1, 1,1,1, 1,1,-1, -1,-1,-1, 1,-1,-1, 1,-1,1, -1,-1,1,
+                1,-1,-1, 1,1,-1, 1,1,1, 1,-1,1, -1,-1,-1, -1,-1,1, -1,1,1, -1,1,-1
+            ],
+            [
+                0,0,1, 0,0,1, 0,0,1, 0,0,1, 0,0,-1, 0,0,-1, 0,0,-1, 0,0,-1,
+                0,1,0, 0,1,0, 0,1,0, 0,1,0, 0,-1,0, 0,-1,0, 0,-1,0, 0,-1,0,
+                1,0,0, 1,0,0, 1,0,0, 1,0,0, -1,0,0, -1,0,0, -1,0,0, -1,0,0
+            ],
+            [0,1,2, 0,2,3, 4,5,6, 4,6,7, 8,9,10, 8,10,11, 12,13,14, 12,14,15, 16,17,18, 16,18,19, 20,21,22, 20,22,23]
+        );
 
-        const planeTexCoords = [
-            0.0,  1.0,
-            1.0,  1.0,
-            1.0,  0.0,
-            0.0,  0.0,
-        ];
-        this.planeTexCoordBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(planeTexCoords), gl.STATIC_DRAW);
+        // Sphere Mesh (UV Sphere)
+        const spPos = [], spNorm = [], spIdx = [];
+        const lat = 16, lon = 16;
+        for(let j=0; j<=lat; j++) {
+            let theta = j * Math.PI / lat;
+            let sinTheta = Math.sin(theta);
+            let cosTheta = Math.cos(theta);
+            for(let i=0; i<=lon; i++) {
+                let phi = i * 2 * Math.PI / lon;
+                let x = Math.cos(phi) * sinTheta;
+                let y = cosTheta;
+                let z = Math.sin(phi) * sinTheta;
+                spPos.push(x, y, z);
+                spNorm.push(x, y, z);
+            }
+        }
+        for(let j=0; j<lat; j++) {
+            for(let i=0; i<lon; i++) {
+                let first = (j * (lon + 1)) + i;
+                let second = first + lon + 1;
+                spIdx.push(first, second, first + 1, second, second + 1, first + 1);
+            }
+        }
+        this.meshSphere = createMesh(spPos, spNorm, spIdx);
 
-        const planeIndices = [0, 1, 2, 0, 2, 3];
-        this.planeIndexBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(planeIndices), gl.STATIC_DRAW);
+        // Plane Mesh (Horizontal XZ)
+        this.meshPlane = createMesh(
+            [-1,0,-1, 1,0,-1, 1,0,1, -1,0,1],
+            [0,1,0, 0,1,0, 0,1,0, 0,1,0],
+            [0,1,2, 0,2,3]
+        );
 
-        const planeNormals = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1];
-        this.planeNormalBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeNormalBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(planeNormals), gl.STATIC_DRAW);
+        // Triangle Mesh (Facing Z+)
+        this.meshTriangle = createMesh(
+            [0,1,0, -1,-1,0, 1,-1,0],
+            [0,0,1, 0,0,1, 0,0,1],
+            [0,1,2]
+        );
 
-        // Basic Cube
-        const positions = [
-            // Front face
-            -1.0, -1.0,  1.0,  1.0, -1.0,  1.0,  1.0,  1.0,  1.0, -1.0,  1.0,  1.0,
-            // Back face
-            -1.0, -1.0, -1.0, -1.0,  1.0, -1.0,  1.0,  1.0, -1.0,  1.0, -1.0, -1.0,
-            // Top face
-            -1.0,  1.0, -1.0, -1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0, -1.0,
-            // Bottom face
-            -1.0, -1.0, -1.0,  1.0, -1.0, -1.0,  1.0, -1.0,  1.0, -1.0, -1.0,  1.0,
-            // Right face
-             1.0, -1.0, -1.0,  1.0,  1.0, -1.0,  1.0,  1.0,  1.0,  1.0, -1.0,  1.0,
-            // Left face
-            -1.0, -1.0, -1.0, -1.0, -1.0,  1.0, -1.0,  1.0,  1.0, -1.0,  1.0, -1.0,
-        ];
-        this.cubeBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.cubeBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+        // Capsule Mesh
+        const capPos = [], capNorm = [], capIdx = [];
+        for(let j=0; j<=lat/2; j++) {
+            let theta = j * Math.PI / lat;
+            let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
+            for(let i=0; i<=lon; i++) {
+                let phi = i * 2 * Math.PI / lon;
+                let x = Math.cos(phi) * sinTheta, y = cosTheta + 0.5, z = Math.sin(phi) * sinTheta;
+                capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
+            }
+        }
+        for(let j=lat/2; j<=lat; j++) {
+            let theta = j * Math.PI / lat;
+            let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
+            for(let i=0; i<=lon; i++) {
+                let phi = i * 2 * Math.PI / lon;
+                let x = Math.cos(phi) * sinTheta, y = cosTheta - 0.5, z = Math.sin(phi) * sinTheta;
+                capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
+            }
+        }
+        for(let j=0; j<lat; j++) {
+            for(let i=0; i<lon; i++) {
+                let first = (j * (lon + 1)) + i, second = first + lon + 1;
+                capIdx.push(first, second, first + 1, second, second + 1, first + 1);
+            }
+        }
+        this.meshCapsule = createMesh(capPos, capNorm, capIdx);
 
-        const indices = [
-            0,  1,  2,      0,  2,  3,    // front
-            4,  5,  6,      4,  6,  7,    // back
-            8,  9,  10,     8,  10, 11,   // top
-            12, 13, 14,     12, 14, 15,   // bottom
-            16, 17, 18,     16, 18, 19,   // right
-            20, 21, 22,     20, 22, 23,   // left
-        ];
-        this.cubeIndexBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.cubeIndexBuffer);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
-
-        const normals = [
-            0,0,1, 0,0,1, 0,0,1, 0,0,1,
-            0,0,-1, 0,0,-1, 0,0,-1, 0,0,-1,
-            0,1,0, 0,1,0, 0,1,0, 0,1,0,
-            0,-1,0, 0,-1,0, 0,-1,0, 0,-1,0,
-            1,0,0, 1,0,0, 1,0,0, 1,0,0,
-            -1,0,0, -1,0,0, -1,0,0, -1,0,0
-        ];
-        this.cubeNormalBuffer = gl.createBuffer();
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.cubeNormalBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(normals), gl.STATIC_DRAW);
+        // Sprite Plane
+        this.meshSpritePlane = createMesh(
+            [-0.5,-0.5,0, 0.5,-0.5,0, 0.5,0.5,0, -0.5,0.5,0],
+            [0,0,1, 0,0,1, 0,0,1, 0,0,1],
+            [0,1,2, 0,2,3],
+            [0,1, 1,1, 1,0, 0,0]
+        );
     }
 
     resize() {
@@ -540,14 +572,21 @@ export class Renderer3D {
         this.clearCache();
 
         // Delete buffers
+        const deleteMesh = (m) => {
+            if (!m) return;
+            if (m.pos) this.gl.deleteBuffer(m.pos);
+            if (m.norm) this.gl.deleteBuffer(m.norm);
+            if (m.idx) this.gl.deleteBuffer(m.idx);
+            if (m.uv) this.gl.deleteBuffer(m.uv);
+        };
+
         if (this.skyBuffer) this.gl.deleteBuffer(this.skyBuffer);
-        if (this.planeBuffer) this.gl.deleteBuffer(this.planeBuffer);
-        if (this.planeTexCoordBuffer) this.gl.deleteBuffer(this.planeTexCoordBuffer);
-        if (this.planeIndexBuffer) this.gl.deleteBuffer(this.planeIndexBuffer);
-        if (this.planeNormalBuffer) this.gl.deleteBuffer(this.planeNormalBuffer);
-        if (this.cubeBuffer) this.gl.deleteBuffer(this.cubeBuffer);
-        if (this.cubeIndexBuffer) this.gl.deleteBuffer(this.cubeIndexBuffer);
-        if (this.cubeNormalBuffer) this.gl.deleteBuffer(this.cubeNormalBuffer);
+        deleteMesh(this.meshCube);
+        deleteMesh(this.meshSphere);
+        deleteMesh(this.meshPlane);
+        deleteMesh(this.meshTriangle);
+        deleteMesh(this.meshCapsule);
+        deleteMesh(this.meshSpritePlane);
 
         // Delete programs
         if (this.skyProgram) this.gl.deleteProgram(this.skyProgram);
@@ -754,49 +793,55 @@ export class Renderer3D {
         }
 
         // --- Render Sky ---
-        if (ambiente.skyMode && ambiente.skyMode !== 'None') {
+        if (ambiente.skyMode && ambiente.skyMode !== 'None' && !options.picking) {
             this.renderSky(ambiente, projectionMatrix, viewMatrix);
         }
 
         // --- Render 3D Grid (Editor only) ---
-        if (options.showGrid) {
+        if (options.showGrid && !options.picking) {
             this.renderGrid(projectionMatrix, viewMatrix);
         }
 
-        gl.useProgram(this.programInfo.program);
-        gl.uniform3fv(this.programInfo.uniformLocations.viewPosition, activeViewPosition);
-        gl.uniform1f(this.programInfo.uniformLocations.uRealismLevel, realismLevel);
-
-        // Global Lights Setup
-        const dirLight = scene.getAllMaterias().find(m => m.isActive && m.getComponent(Components3D.DirectionalLight3D));
-        if (dirLight) {
-            const dlComp = dirLight.getComponent(Components3D.DirectionalLight3D);
-            gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [dlComp.direction.x, dlComp.direction.y, dlComp.direction.z]);
-            gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, this.hexToRgb(dlComp.color).map(c => c * dlComp.intensity));
-        } else {
-            gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [0, -1, 0]);
-            gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, [1, 1, 1]);
+        if (options.picking) {
+            gl.useProgram(this.pickingProgramInfo.program);
         }
-        gl.uniform3fv(this.programInfo.uniformLocations.uAmbientLight, [0.3, 0.3, 0.3]);
 
-        // Point Lights Setup
-        const pointLights = scene.getAllMaterias().filter(m => m.isActive && m.getComponent(Components3D.PointLight3D)).slice(0, 4);
-        const plPos = [], plColor = [], plRange = [];
-        pointLights.forEach(pl => {
-            const comp = pl.getComponent(Components3D.PointLight3D);
-            const trans = pl.getComponent(Transform);
-            plPos.push(trans.x, trans.y, trans.z);
-            const rgb = this.hexToRgb(comp.color);
-            plColor.push(rgb[0] * comp.intensity, rgb[1] * comp.intensity, rgb[2] * comp.intensity);
-            plRange.push(comp.range);
-        });
+        if (!options.picking) {
+            gl.useProgram(this.programInfo.program);
+            gl.uniform3fv(this.programInfo.uniformLocations.viewPosition, activeViewPosition);
+            gl.uniform1f(this.programInfo.uniformLocations.uRealismLevel, realismLevel);
 
-        if (pointLights.length > 0) {
-            gl.uniform3fv(this.programInfo.uniformLocations.uPointLightPos, new Float32Array(plPos));
-            gl.uniform3fv(this.programInfo.uniformLocations.uPointLightColor, new Float32Array(plColor));
-            gl.uniform1fv(this.programInfo.uniformLocations.uPointLightRange, new Float32Array(plRange));
+            // Global Lights Setup
+            const dirLight = scene.getAllMaterias().find(m => m.isActive && m.getComponent(Components3D.DirectionalLight3D));
+            if (dirLight) {
+                const dlComp = dirLight.getComponent(Components3D.DirectionalLight3D);
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [dlComp.direction.x, dlComp.direction.y, dlComp.direction.z]);
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, this.hexToRgb(dlComp.color).map(c => c * dlComp.intensity));
+            } else {
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [0, -1, 0]);
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, [1, 1, 1]);
+            }
+            gl.uniform3fv(this.programInfo.uniformLocations.uAmbientLight, [0.3, 0.3, 0.3]);
+
+            // Point Lights Setup
+            const pointLights = scene.getAllMaterias().filter(m => m.isActive && m.getComponent(Components3D.PointLight3D)).slice(0, 4);
+            const plPos = [], plColor = [], plRange = [];
+            pointLights.forEach(pl => {
+                const comp = pl.getComponent(Components3D.PointLight3D);
+                const trans = pl.getComponent(Transform);
+                plPos.push(trans.x, trans.y, trans.z);
+                const rgb = this.hexToRgb(comp.color);
+                plColor.push(rgb[0] * comp.intensity, rgb[1] * comp.intensity, rgb[2] * comp.intensity);
+                plRange.push(comp.range);
+            });
+
+            if (pointLights.length > 0) {
+                gl.uniform3fv(this.programInfo.uniformLocations.uPointLightPos, new Float32Array(plPos));
+                gl.uniform3fv(this.programInfo.uniformLocations.uPointLightColor, new Float32Array(plColor));
+                gl.uniform1fv(this.programInfo.uniformLocations.uPointLightRange, new Float32Array(plRange));
+            }
+            gl.uniform1i(this.programInfo.uniformLocations.uPointLightCount, pointLights.length);
         }
-        gl.uniform1i(this.programInfo.uniformLocations.uPointLightCount, pointLights.length);
 
         // Optimization: Filter out non-renderable materias once per frame
         const renderableMaterias = scene.getAllMaterias().filter(m => {
@@ -960,46 +1005,45 @@ export class Renderer3D {
             color = [rgb[0], rgb[1], rgb[2], 1.0];
         }
 
-        const isToon = options.isToon || meshRenderer?.isToon || (window.SceneManager.currentScene.ambiente.graphicMode === 'Anime');
-        gl.uniform4fv(this.programInfo.uniformLocations.uColor, color);
-        gl.uniform1i(this.programInfo.uniformLocations.uUseToon, isToon ? 1 : 0);
+        if (!options.picking) {
+            const isToon = options.isToon || meshRenderer?.isToon || (window.SceneManager.currentScene.ambiente.graphicMode === 'Anime');
+            gl.uniform4fv(this.programInfo.uniformLocations.uColor, color);
+            gl.uniform1i(this.programInfo.uniformLocations.uUseToon, isToon ? 1 : 0);
+        }
 
         if (meshRenderer) {
             if (options.picking) {
                 const id = options.idMap.get(materia.id);
-                const pickingColor = [
-                    ((id >>  0) & 0xFF) / 255,
-                    ((id >>  8) & 0xFF) / 255,
-                    ((id >> 16) & 0xFF) / 255,
-                    1.0
-                ];
+                const pickingColor = [((id >> 0) & 0xFF) / 255, ((id >> 8) & 0xFF) / 255, ((id >> 16) & 0xFF) / 255, 1.0];
                 gl.uniform4fv(programInfo.uniformLocations.uPickingColor, pickingColor);
             } else {
                 gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 0);
             }
-            // TODO: Support Sphere/Plane
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.cubeBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
 
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.cubeNormalBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
+            let mesh = this.meshCube;
+            if (meshRenderer.meshType === 'Sphere') mesh = this.meshSphere;
+            else if (meshRenderer.meshType === 'Plane') mesh = this.meshPlane;
+            else if (meshRenderer.meshType === 'Triangle') mesh = this.meshTriangle;
+            else if (meshRenderer.meshType === 'Capsule') mesh = this.meshCapsule;
 
-            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.cubeIndexBuffer);
-            gl.drawElements(gl.TRIANGLES, 36, gl.UNSIGNED_SHORT, 0);
+            gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
+            gl.vertexAttribPointer(programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
+
+            if (!options.picking) {
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.norm);
+                gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
+                gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
+            }
+
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+            gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
         } else if (spriteRenderer) {
             if (options.picking) {
                 const id = options.idMap.get(materia.id);
-                const pickingColor = [
-                    ((id >>  0) & 0xFF) / 255,
-                    ((id >>  8) & 0xFF) / 255,
-                    ((id >> 16) & 0xFF) / 255,
-                    1.0
-                ];
+                const pickingColor = [((id >> 0) & 0xFF) / 255, ((id >> 8) & 0xFF) / 255, ((id >> 16) & 0xFF) / 255, 1.0];
                 gl.uniform4fv(programInfo.uniformLocations.uPickingColor, pickingColor);
             }
-            // Draw sprite as plane
             if (!options.picking) {
                 const tex = this.getGLTexture(spriteRenderer.sprite);
                 if (tex) {
@@ -1012,10 +1056,8 @@ export class Renderer3D {
                 }
             }
 
-            // Adjust model matrix for sprite dimensions (2D to 3D mapping)
             const sprite = spriteRenderer.sprite;
-            let spriteScaleX = 1;
-            let spriteScaleY = 1;
+            let spriteScaleX = 1, spriteScaleY = 1;
             if (sprite && sprite.complete && sprite.naturalWidth > 0) {
                 spriteScaleX = sprite.naturalWidth;
                 spriteScaleY = sprite.naturalHeight;
@@ -1023,46 +1065,37 @@ export class Renderer3D {
 
             const spriteModelMatrix = mat4.create();
             const spriteScale = [scale[0] * spriteScaleX, scale[1] * spriteScaleY, 1];
-
             let finalRotation = q;
             if (spriteRenderer.billboard && !options.picking) {
-                // Spherical Billboarding: face the camera position
                 const viewRot = quat.create();
                 mat4.getRotation(viewRot, viewMatrix);
                 quat.invert(viewRot, viewRot);
-                // Combine billboard rotation with local rotation for flexibility
                 quat.multiply(finalRotation, viewRot, q);
             }
-
             mat4.fromRotationTranslationScale(spriteModelMatrix, finalRotation, pos, spriteScale);
             gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, spriteModelMatrix);
 
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
+            const mesh = this.meshSpritePlane;
+            gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
+            gl.vertexAttribPointer(programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
 
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeNormalBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
-
-            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-            gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+            if (!options.picking) {
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
+                gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
+                gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.norm);
+                gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
+                gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
+            }
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+            gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
         } else if (textureRender) {
             if (options.picking) {
                 const id = options.idMap.get(materia.id);
-                const pickingColor = [
-                    ((id >>  0) & 0xFF) / 255,
-                    ((id >>  8) & 0xFF) / 255,
-                    ((id >> 16) & 0xFF) / 255,
-                    1.0
-                ];
+                const pickingColor = [((id >> 0) & 0xFF) / 255, ((id >> 8) & 0xFF) / 255, ((id >> 16) & 0xFF) / 255, 1.0];
                 gl.uniform4fv(programInfo.uniformLocations.uPickingColor, pickingColor);
             }
-
             if (!options.picking) {
                 const tex = this.getGLTexture(textureRender.texture);
                 if (tex) {
@@ -1077,33 +1110,31 @@ export class Renderer3D {
 
             const modelMatrixTex = mat4.create();
             const texScale = [scale[0] * textureRender.width, scale[1] * textureRender.height, 1];
-
             let finalRotationTex = q;
             if (textureRender.billboard && !options.picking) {
                 const viewRot = quat.create();
                 mat4.getRotation(viewRot, viewMatrix);
                 quat.invert(viewRot, viewRot);
-                // Combine billboard rotation with local rotation
                 quat.multiply(finalRotationTex, viewRot, q);
             }
-
             mat4.fromRotationTranslationScale(modelMatrixTex, finalRotationTex, pos, texScale);
             gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, modelMatrixTex);
 
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
+            const mesh = this.meshSpritePlane;
+            gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
+            gl.vertexAttribPointer(programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
 
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.planeNormalBuffer);
-            gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
-            gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
-
-            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-            gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+            if (!options.picking) {
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
+                gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
+                gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
+                gl.bindBuffer(gl.ARRAY_BUFFER, mesh.norm);
+                gl.vertexAttribPointer(this.programInfo.attribLocations.vertexNormal, 3, gl.FLOAT, false, 0, 0);
+                gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexNormal);
+            }
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+            gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
         }
     }
 
@@ -1169,14 +1200,12 @@ export class Renderer3D {
      * This avoids the "flat background" look by placing it correctly in 3D space.
      */
     renderTilemap(materia, projectionMatrix, viewMatrix, options) {
-        if (options.picking) return; // Skip picking for tilemaps for now
+        if (options.picking) return;
 
         const tilemap = materia.getComponent(Components.Tilemap);
         const tilemapRenderer = materia.getComponent(Components.TilemapRenderer);
         const transform = materia.getComponent(Transform);
 
-        // We use the 2D renderer to bake the tilemap into a texture
-        // This is a shortcut to avoid implementing the whole tilemap logic in GL
         if (!tilemapRenderer._bakedTexture || tilemapRenderer.isDirty) {
             this.bakeTilemap(materia);
         }
@@ -1191,38 +1220,29 @@ export class Renderer3D {
         const scale = [Math.abs(worldScale.x), Math.abs(worldScale.y), 1];
 
         const q = quat.create();
-        const rot = {
-            x: transform.rotationX || 0,
-            y: transform.rotationY || 0,
-            z: transform.rotationZ || 0
-        };
-        quat.fromEuler(q, rot.x, rot.y, rot.z);
+        quat.fromEuler(q, transform.rotationX || 0, transform.rotationY || 0, transform.rotationZ || 0);
 
         const modelMatrix = mat4.create();
         const mapScale = [tilemapRenderer._bakedTexture.width, tilemapRenderer._bakedTexture.height, 1];
         const finalScale = [scale[0] * mapScale[0], scale[1] * mapScale[1], 1];
-
         mat4.fromRotationTranslationScale(modelMatrix, q, pos, finalScale);
 
         gl.uniformMatrix4fv(this.programInfo.uniformLocations.projectionMatrix, false, projectionMatrix);
         gl.uniformMatrix4fv(this.programInfo.uniformLocations.viewMatrix, false, viewMatrix);
         gl.uniformMatrix4fv(this.programInfo.uniformLocations.modelMatrix, false, modelMatrix);
-
         gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 1);
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.uniform1i(this.programInfo.uniformLocations.uSampler, 0);
 
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
+        const mesh = this.meshSpritePlane;
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
         gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
         gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
-
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-        gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+        gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     bakeTilemap(materia) {
@@ -1278,7 +1298,6 @@ export class Renderer3D {
         const terreno = materia.getComponent(Components.Terreno2D);
         if (!terreno || options.picking) return;
 
-        // Use the 2D logic to bake terrain into a texture
         if (!terreno._bakedTexture || terreno.isDirty) {
             this.bakeTerreno2D(materia);
         }
@@ -1303,20 +1322,19 @@ export class Renderer3D {
         gl.uniformMatrix4fv(this.programInfo.uniformLocations.viewMatrix, false, viewMatrix);
         gl.uniformMatrix4fv(this.programInfo.uniformLocations.modelMatrix, false, modelMatrix);
         gl.uniform4fv(this.programInfo.uniformLocations.uColor, [1, 1, 1, 1]);
-
         gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 1);
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.uniform1i(this.programInfo.uniformLocations.uSampler, 0);
 
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
+        const mesh = this.meshSpritePlane;
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
         gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
         gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-        gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+        gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     bakeTerreno2D(materia) {
@@ -1349,10 +1367,8 @@ export class Renderer3D {
         const water = materia.getComponent(Components.Water);
         if (!water || options.picking) return;
 
-        // Render water particles as additive/blended spheres or a baked mesh
-        // For simplicity in v0.1.2 hybrid, we bake it to a texture based on its bounds
         const now = performance.now();
-        const shouldUpdate = !water._bakedTexture || (now - (water._lastBakeTime || 0) > 33); // ~30fps update
+        const shouldUpdate = !water._bakedTexture || (now - (water._lastBakeTime || 0) > 33);
 
         if (shouldUpdate) {
             this.bakeWater(materia);
@@ -1380,14 +1396,16 @@ export class Renderer3D {
         gl.uniform1i(this.programInfo.uniformLocations.uUseTexture, 1);
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeBuffer);
+
+        const mesh = this.meshSpritePlane;
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.pos);
         gl.vertexAttribPointer(this.programInfo.attribLocations.vertexPosition, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.vertexPosition);
-        gl.bindBuffer(gl.ARRAY_BUFFER, this.planeTexCoordBuffer);
+        gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uv);
         gl.vertexAttribPointer(this.programInfo.attribLocations.textureCoord, 2, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(this.programInfo.attribLocations.textureCoord);
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.planeIndexBuffer);
-        gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.idx);
+        gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     bakeWater(materia) {

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -369,26 +369,31 @@ export class Renderer3D {
 
             vec4 grid(vec3 fragPos3D, float scale) {
                 vec2 coord = fragPos3D.xz * scale;
+                // Offset slightly to center origin lines
+                coord += 0.5 * fwidth(coord);
                 vec2 derivative = fwidth(coord);
                 vec2 grid = abs(fract(coord - 0.5) - 0.5) / derivative;
                 float line = min(grid.x, grid.y);
                 float minimumz = min(derivative.y, 1.0);
                 float minimumx = min(derivative.x, 1.0);
-                vec4 color = vec4(0.2, 0.2, 0.2, 1.0 - min(line, 1.0));
+                vec4 color = vec4(0.15, 0.15, 0.15, 1.0 - min(line, 1.0));
 
-                // Z-Axis (Blue)
-                if (fragPos3D.x > -0.1 * minimumx && fragPos3D.x < 0.1 * minimumx)
-                    color.rgb = vec3(0.0, 0.0, 1.0);
+                // Z-Axis (Blue) - Slightly thicker and brighter for infinite grid
+                if (fragPos3D.x > -0.15 * minimumx && fragPos3D.x < 0.15 * minimumx)
+                    color.rgb = vec3(0.0, 0.3, 1.0);
                 // X-Axis (Red)
-                if (fragPos3D.z > -0.1 * minimumz && fragPos3D.z < 0.1 * minimumz)
-                    color.rgb = vec3(1.0, 0.0, 0.0);
+                if (fragPos3D.z > -0.15 * minimumz && fragPos3D.z < 0.15 * minimumz)
+                    color.rgb = vec3(1.0, 0.2, 0.2);
 
                 return color;
             }
 
             float computeDepth(vec3 pos) {
                 vec4 clipSpacePos = uProj * uView * vec4(pos.xyz, 1.0);
-                return (clipSpacePos.z / clipSpacePos.w);
+                // Map NDC z (-1 to 1) to depth buffer range (0 to 1)
+                float ndcZ = clipSpacePos.z / clipSpacePos.w;
+                // Add a tiny bias to prevent Z-fighting with the ground plane
+                return (ndcZ * 0.5 + 0.5) + 0.00001;
             }
 
             float computeLinearDepth(vec3 pos) {
@@ -399,8 +404,10 @@ export class Renderer3D {
             }
 
             void main() {
+                // Plane intersection with Y=0
+                // Since world Y is inverted, the ground plane is still at world Y=0
                 float t = -vNearPoint.y / (vFarPoint.y - vNearPoint.y);
-                if (t < 0.0) discard;
+                if (t < 0.0 || t > 1.0) discard;
 
                 vec3 fragPos3D = vNearPoint + t * (vFarPoint - vNearPoint);
                 gl_FragDepthEXT = computeDepth(fragPos3D);
@@ -461,12 +468,12 @@ export class Renderer3D {
         gl.bindBuffer(gl.ARRAY_BUFFER, this.skyBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(quadPositions), gl.STATIC_DRAW);
 
-        // Cube Mesh (2x2x2)
+        // Cube Mesh (1x1x1)
         this.meshCube = createMesh(
             [
-                -1,-1,1, 1,-1,1, 1,1,1, -1,1,1, -1,-1,-1, -1,1,-1, 1,1,-1, 1,-1,-1,
-                -1,1,-1, -1,1,1, 1,1,1, 1,1,-1, -1,-1,-1, 1,-1,-1, 1,-1,1, -1,-1,1,
-                1,-1,-1, 1,1,-1, 1,1,1, 1,-1,1, -1,-1,-1, -1,-1,1, -1,1,1, -1,1,-1
+                -0.5,-0.5,0.5, 0.5,-0.5,0.5, 0.5,0.5,0.5, -0.5,0.5,0.5, -0.5,-0.5,-0.5, -0.5,0.5,-0.5, 0.5,0.5,-0.5, 0.5,-0.5,-0.5,
+                -0.5,0.5,-0.5, -0.5,0.5,0.5, 0.5,0.5,0.5, 0.5,0.5,-0.5, -0.5,-0.5,-0.5, 0.5,-0.5,-0.5, 0.5,-0.5,0.5, -0.5,-0.5,0.5,
+                0.5,-0.5,-0.5, 0.5,0.5,-0.5, 0.5,0.5,0.5, 0.5,-0.5,0.5, -0.5,-0.5,-0.5, -0.5,-0.5,0.5, -0.5,0.5,0.5, -0.5,0.5,-0.5
             ],
             [
                 0,0,1, 0,0,1, 0,0,1, 0,0,1, 0,0,-1, 0,0,-1, 0,0,-1, 0,0,-1,
@@ -476,7 +483,7 @@ export class Renderer3D {
             [0,1,2, 0,2,3, 4,5,6, 4,6,7, 8,9,10, 8,10,11, 12,13,14, 12,14,15, 16,17,18, 16,18,19, 20,21,22, 20,22,23]
         );
 
-        // Sphere Mesh (UV Sphere)
+        // Sphere Mesh (UV Sphere, radius 0.5)
         const spPos = [], spNorm = [], spIdx = [];
         const lat = 16, lon = 16;
         for(let j=0; j<=lat; j++) {
@@ -485,11 +492,11 @@ export class Renderer3D {
             let cosTheta = Math.cos(theta);
             for(let i=0; i<=lon; i++) {
                 let phi = i * 2 * Math.PI / lon;
-                let x = Math.cos(phi) * sinTheta;
-                let y = cosTheta;
-                let z = Math.sin(phi) * sinTheta;
+                let x = Math.cos(phi) * sinTheta * 0.5;
+                let y = cosTheta * 0.5;
+                let z = Math.sin(phi) * sinTheta * 0.5;
                 spPos.push(x, y, z);
-                spNorm.push(x, y, z);
+                spNorm.push(x / 0.5, y / 0.5, z / 0.5);
             }
         }
         for(let j=0; j<lat; j++) {
@@ -501,29 +508,29 @@ export class Renderer3D {
         }
         this.meshSphere = createMesh(spPos, spNorm, spIdx);
 
-        // Plane Mesh (Horizontal XZ)
+        // Plane Mesh (Horizontal XZ, 1x1)
         this.meshPlane = createMesh(
-            [-1,0,-1, 1,0,-1, 1,0,1, -1,0,1],
+            [-0.5,0,-0.5, 0.5,0,-0.5, 0.5,0,0.5, -0.5,0,0.5],
             [0,1,0, 0,1,0, 0,1,0, 0,1,0],
             [0,1,2, 0,2,3]
         );
 
-        // Triangle Mesh (Facing Z+)
+        // Triangle Mesh (Facing Z+, height 1, base 1)
         this.meshTriangle = createMesh(
-            [0,1,0, -1,-1,0, 1,-1,0],
+            [0,0.5,0, -0.5,-0.5,0, 0.5,-0.5,0],
             [0,0,1, 0,0,1, 0,0,1],
             [0,1,2]
         );
 
-        // Capsule Mesh (Total height 2, Radius 0.5)
+        // Capsule Mesh (Total height 1, Radius 0.25)
         const capPos = [], capNorm = [], capIdx = [];
         for(let j=0; j<=lat/2; j++) {
             let theta = j * Math.PI / lat;
             let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
             for(let i=0; i<=lon; i++) {
                 let phi = i * 2 * Math.PI / lon;
-                let x = Math.cos(phi) * sinTheta * 0.5, y = cosTheta * 0.5 + 0.5, z = Math.sin(phi) * sinTheta * 0.5;
-                capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
+                let x = Math.cos(phi) * sinTheta * 0.25, y = cosTheta * 0.25 + 0.25, z = Math.sin(phi) * sinTheta * 0.25;
+                capPos.push(x, y, z); capNorm.push(x / 0.25, cosTheta, z / 0.25);
             }
         }
         for(let j=lat/2; j<=lat; j++) {
@@ -531,8 +538,8 @@ export class Renderer3D {
             let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
             for(let i=0; i<=lon; i++) {
                 let phi = i * 2 * Math.PI / lon;
-                let x = Math.cos(phi) * sinTheta * 0.5, y = cosTheta * 0.5 - 0.5, z = Math.sin(phi) * sinTheta * 0.5;
-                capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
+                let x = Math.cos(phi) * sinTheta * 0.25, y = cosTheta * 0.25 - 0.25, z = Math.sin(phi) * sinTheta * 0.25;
+                capPos.push(x, y, z); capNorm.push(x / 0.25, cosTheta, z / 0.25);
             }
         }
         for(let j=0; j<lat; j++) {
@@ -676,6 +683,7 @@ export class Renderer3D {
 
         const invViewProj = mat4.create();
         const viewNoPos = mat4.clone(viewMatrix);
+        // Important: View matrix already has inverted Y if coming from render()
         viewNoPos[12] = 0; viewNoPos[13] = 0; viewNoPos[14] = 0; // Remove translation
         mat4.multiply(invViewProj, projectionMatrix, viewNoPos);
         mat4.invert(invViewProj, invViewProj);
@@ -754,16 +762,11 @@ export class Renderer3D {
         const projectionMatrix = mat4.create();
         const viewMatrix = mat4.create();
 
-        this.lastProjectionMatrix = projectionMatrix;
-        this.lastViewMatrix = viewMatrix;
+        const near = 0.1;
+        const far = 100000;
 
         let activeViewPosition = [0, 0, 0];
         let aspect = gl.canvas.width / gl.canvas.height;
-        if (options.picking) {
-            // Match the aspect ratio of the picking viewport (square 512x512)
-            // or better, keep the canvas aspect to match what user sees
-            // aspect = 1.0;
-        }
 
         if (cameraMateria) {
             const camComp = cameraMateria.getComponent(Camera);
@@ -773,16 +776,16 @@ export class Renderer3D {
                 const size = camComp.orthographicSize;
                 const orthoH = size;
                 const orthoW = size * aspect;
-                // Reverse Y for orthographic to match 2D Canvas coordinate system (Y-down)
-                mat4.ortho(projectionMatrix, -orthoW, orthoW, orthoH, -orthoH, 0.1, 10000);
+                mat4.ortho(projectionMatrix, -orthoW, orthoW, -orthoH, orthoH, near, far);
             } else {
-                mat4.perspective(projectionMatrix, camComp.fov * Math.PI / 180, aspect, 0.1, 50000);
+                mat4.perspective(projectionMatrix, camComp.fov * Math.PI / 180, aspect, near, far);
             }
 
             const q = quat.create();
-            // Important: Camera in CE uses standard Euler for 3D
+            // Invert Pitch and Roll for Y-inversion?
+            // Actually, keep Euler as is, but we'll negate Y pos
             quat.fromEuler(q, camTrans.localRotation.x, camTrans.localRotation.y, camTrans.localRotation.z);
-            activeViewPosition = [camTrans.x, camTrans.y, camTrans.z];
+            activeViewPosition = [camTrans.x, -camTrans.y, camTrans.z];
             mat4.fromRotationTranslation(viewMatrix, q, activeViewPosition);
             mat4.invert(viewMatrix, viewMatrix);
         } else {
@@ -791,12 +794,17 @@ export class Renderer3D {
             const q = quat.create();
             quat.fromEuler(q, editorCam.rotation.x, editorCam.rotation.y, editorCam.rotation.z);
 
-            // Use Perspective for 3D Scene View
-            mat4.perspective(projectionMatrix, 45 * Math.PI / 180, aspect, 1, 100000);
+            mat4.perspective(projectionMatrix, 45 * Math.PI / 180, aspect, near, far);
 
-            activeViewPosition = [editorCam.x, editorCam.y, editorCam.z];
+            activeViewPosition = [editorCam.x, -editorCam.y, editorCam.z];
             mat4.fromRotationTranslation(viewMatrix, q, activeViewPosition);
             mat4.invert(viewMatrix, viewMatrix);
+        }
+
+        // Only store the "last" matrices if this is the main rendering pass (not picking)
+        if (!options.picking) {
+            this.lastProjectionMatrix = mat4.clone(projectionMatrix);
+            this.lastViewMatrix = mat4.clone(viewMatrix);
         }
 
         // --- Render Sky ---
@@ -824,10 +832,10 @@ export class Renderer3D {
             const dirLight = scene.getAllMaterias().find(m => m.isActive && m.getComponent(Components3D.DirectionalLight3D));
             if (dirLight) {
                 const dlComp = dirLight.getComponent(Components3D.DirectionalLight3D);
-                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [dlComp.direction.x, dlComp.direction.y, dlComp.direction.z]);
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [dlComp.direction.x, -dlComp.direction.y, dlComp.direction.z]);
                 gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, this.hexToRgb(dlComp.color).map(c => c * dlComp.intensity));
             } else {
-                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [0, -1, 0]);
+                gl.uniform3fv(this.programInfo.uniformLocations.uDirLightDir, [0, -1, 0]); // Default pointing Down
                 gl.uniform3fv(this.programInfo.uniformLocations.uDirLightColor, [1, 1, 1]);
             }
             gl.uniform3fv(this.programInfo.uniformLocations.uAmbientLight, [0.3, 0.3, 0.3]);
@@ -838,7 +846,7 @@ export class Renderer3D {
             pointLights.forEach(pl => {
                 const comp = pl.getComponent(Components3D.PointLight3D);
                 const trans = pl.getComponent(Transform);
-                plPos.push(trans.x, trans.y, trans.z || 0);
+                plPos.push(trans.x, -trans.y, trans.z || 0);
                 const rgb = this.hexToRgb(comp.color);
                 plColor.push(rgb[0] * comp.intensity, rgb[1] * comp.intensity, rgb[2] * comp.intensity);
                 plRange.push(comp.range);
@@ -978,7 +986,7 @@ export class Renderer3D {
         const modelMatrix = mat4.create();
         const worldPos = transform.position;
         const worldScale = transform.scale;
-        const pos = [worldPos.x, worldPos.y, worldPos.z || 0];
+        const pos = [worldPos.x, -worldPos.y, worldPos.z || 0];
         const scale = [Math.abs(worldScale.x), Math.abs(worldScale.y), Math.abs(worldScale.z || 1)];
 
         const q = quat.create();
@@ -1207,8 +1215,11 @@ export class Renderer3D {
         this.render(scene, cameraMateria, { ...options, picking: true, idMap });
 
         const pixels = new Uint8Array(4);
-        // Correct Y for WebGL (bottom-up)
-        gl.readPixels(x, h - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        // Correct Y for WebGL (bottom-up).
+        // Screen Y: 0 (top) to h-1 (bottom).
+        // WebGL Y: 0 (bottom) to h-1 (top).
+        // So screen y -> gl y = (h - 1) - y
+        gl.readPixels(x, (h - 1) - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
         const pickedId = pixels[0] + (pixels[1] << 8) + (pixels[2] << 16);
@@ -1236,7 +1247,7 @@ export class Renderer3D {
         const gl = this.gl;
         const worldPos = transform.position;
         const worldScale = transform.scale;
-        const pos = [worldPos.x, worldPos.y, worldPos.z || 0];
+        const pos = [worldPos.x, -worldPos.y, worldPos.z || 0];
         const scale = [Math.abs(worldScale.x), Math.abs(worldScale.y), 1];
 
         const q = quat.create();
@@ -1329,7 +1340,7 @@ export class Renderer3D {
         const transform = materia.getComponent(Transform);
         const worldPos = transform.position;
         const worldScale = transform.scale;
-        const pos = [worldPos.x, worldPos.y, worldPos.z || 0];
+        const pos = [worldPos.x, -worldPos.y, worldPos.z || 0];
 
         const q = quat.create();
         quat.fromEuler(q, transform.rotationX || 0, transform.rotationY || 0, transform.rotationZ || 0);
@@ -1405,7 +1416,7 @@ export class Renderer3D {
         const h = bounds.maxY - bounds.minY;
         if (w <= 0 || h <= 0) return;
 
-        const pos = [bounds.minX + w/2, bounds.minY + h/2, transform.z || 0];
+        const pos = [bounds.minX + w/2, -(bounds.minY + h/2), transform.z || 0];
         const modelMatrix = mat4.create();
         mat4.fromRotationTranslationScale(modelMatrix, quat.create(), pos, [w, h, 1]);
 

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -1,5 +1,6 @@
 import * as Components from './Components.js';
 import * as Components3D from './Components3D.js';
+window.Components3D = Components3D; // Ensure global access for Inspector and Editor
 const { Transform, SpriteRenderer, Camera } = Components;
 const { MeshRenderer3D, DirectionalLight3D, PointLight3D, SpotLight3D } = Components3D;
 
@@ -514,14 +515,14 @@ export class Renderer3D {
             [0,1,2]
         );
 
-        // Capsule Mesh
+        // Capsule Mesh (Total height 2, Radius 0.5)
         const capPos = [], capNorm = [], capIdx = [];
         for(let j=0; j<=lat/2; j++) {
             let theta = j * Math.PI / lat;
             let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
             for(let i=0; i<=lon; i++) {
                 let phi = i * 2 * Math.PI / lon;
-                let x = Math.cos(phi) * sinTheta, y = cosTheta + 0.5, z = Math.sin(phi) * sinTheta;
+                let x = Math.cos(phi) * sinTheta * 0.5, y = cosTheta * 0.5 + 0.5, z = Math.sin(phi) * sinTheta * 0.5;
                 capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
             }
         }
@@ -530,7 +531,7 @@ export class Renderer3D {
             let sinTheta = Math.sin(theta), cosTheta = Math.cos(theta);
             for(let i=0; i<=lon; i++) {
                 let phi = i * 2 * Math.PI / lon;
-                let x = Math.cos(phi) * sinTheta, y = cosTheta - 0.5, z = Math.sin(phi) * sinTheta;
+                let x = Math.cos(phi) * sinTheta * 0.5, y = cosTheta * 0.5 - 0.5, z = Math.sin(phi) * sinTheta * 0.5;
                 capPos.push(x, y, z); capNorm.push(x, cosTheta, z);
             }
         }
@@ -718,6 +719,7 @@ export class Renderer3D {
             if (!this.init()) return;
         }
         if (!this.gl) return;
+        window._Renderer3D = this; // Ensure global reference for SceneView
         const gl = this.gl;
         const ambiente = scene.ambiente || {};
         const realismLevel = (ambiente.realismLevel !== undefined ? ambiente.realismLevel : 50) / 100;
@@ -756,7 +758,12 @@ export class Renderer3D {
         this.lastViewMatrix = viewMatrix;
 
         let activeViewPosition = [0, 0, 0];
-        const aspect = gl.canvas.width / gl.canvas.height;
+        let aspect = gl.canvas.width / gl.canvas.height;
+        if (options.picking) {
+            // Match the aspect ratio of the picking viewport (square 512x512)
+            // or better, keep the canvas aspect to match what user sees
+            // aspect = 1.0;
+        }
 
         if (cameraMateria) {
             const camComp = cameraMateria.getComponent(Camera);
@@ -804,10 +811,12 @@ export class Renderer3D {
 
         if (options.picking) {
             gl.useProgram(this.pickingProgramInfo.program);
-        }
-
-        if (!options.picking) {
+        } else {
             gl.useProgram(this.programInfo.program);
+            // Apply projection/view once for the main pass
+            gl.uniformMatrix4fv(this.programInfo.uniformLocations.projectionMatrix, false, projectionMatrix);
+            gl.uniformMatrix4fv(this.programInfo.uniformLocations.viewMatrix, false, viewMatrix);
+
             gl.uniform3fv(this.programInfo.uniformLocations.viewPosition, activeViewPosition);
             gl.uniform1f(this.programInfo.uniformLocations.uRealismLevel, realismLevel);
 
@@ -829,7 +838,7 @@ export class Renderer3D {
             pointLights.forEach(pl => {
                 const comp = pl.getComponent(Components3D.PointLight3D);
                 const trans = pl.getComponent(Transform);
-                plPos.push(trans.x, trans.y, trans.z);
+                plPos.push(trans.x, trans.y, trans.z || 0);
                 const rgb = this.hexToRgb(comp.color);
                 plColor.push(rgb[0] * comp.intensity, rgb[1] * comp.intensity, rgb[2] * comp.intensity);
                 plRange.push(comp.range);
@@ -942,14 +951,12 @@ export class Renderer3D {
 
         if (options.picking && !meshRenderer && !spriteRenderer && !textureRender) return;
 
-        const gl = this.gl;
-        const programInfo = options.picking ? this.pickingProgramInfo : this.programInfo;
         const transform = materia.getComponent(Transform);
         if (!transform || !materia.isActive) return;
 
         if (!meshRenderer && !spriteRenderer && !textureRender && !tilemapRenderer && !terreno2D && !water) return;
 
-        // Specialized Renderers
+        // Specialized Renderers (Always non-picking for these complex ones for now)
         if (tilemapRenderer) {
             this.renderTilemap(materia, projectionMatrix, viewMatrix, options);
             return;
@@ -962,6 +969,11 @@ export class Renderer3D {
             this.renderWater(materia, projectionMatrix, viewMatrix, options);
             return;
         }
+
+        const gl = this.gl;
+        // Ensure the correct program is active for this materia
+        const programInfo = options.picking ? this.pickingProgramInfo : this.programInfo;
+        gl.useProgram(programInfo.program);
 
         const modelMatrix = mat4.create();
         const worldPos = transform.position;
@@ -980,6 +992,7 @@ export class Renderer3D {
 
         mat4.fromRotationTranslationScale(modelMatrix, q, pos, scale);
 
+        // ALWAYS set these because the program might have changed
         gl.uniformMatrix4fv(programInfo.uniformLocations.projectionMatrix, false, projectionMatrix);
         gl.uniformMatrix4fv(programInfo.uniformLocations.viewMatrix, false, viewMatrix);
         gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, modelMatrix);
@@ -1005,7 +1018,7 @@ export class Renderer3D {
             color = [rgb[0], rgb[1], rgb[2], 1.0];
         }
 
-        if (!options.picking) {
+        if (!options.picking && this.programInfo.uniformLocations.uColor) {
             const isToon = options.isToon || meshRenderer?.isToon || (window.SceneManager.currentScene.ambiente.graphicMode === 'Anime');
             gl.uniform4fv(this.programInfo.uniformLocations.uColor, color);
             gl.uniform1i(this.programInfo.uniformLocations.uUseToon, isToon ? 1 : 0);
@@ -1151,12 +1164,20 @@ export class Renderer3D {
         if (!this.gl) return null;
         const gl = this.gl;
 
-        // Setup picking texture
-        const pickingRes = 512; // Lower resolution for optimization
-        if (!this.pickingFramebuffer) {
+        // Setup picking texture at canvas resolution for exact match
+        const w = gl.canvas.width;
+        const h = gl.canvas.height;
+
+        if (!this.pickingFramebuffer || this._pickW !== w || this._pickH !== h) {
+            if (this.pickingFramebuffer) {
+                gl.deleteFramebuffer(this.pickingFramebuffer);
+                gl.deleteTexture(this.pickingTexture);
+                gl.deleteRenderbuffer(this.pickingDepthBuffer);
+            }
+
             this.pickingTexture = gl.createTexture();
             gl.bindTexture(gl.TEXTURE_2D, this.pickingTexture);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, pickingRes, pickingRes, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 
             this.pickingFramebuffer = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, this.pickingFramebuffer);
@@ -1164,12 +1185,15 @@ export class Renderer3D {
 
             this.pickingDepthBuffer = gl.createRenderbuffer();
             gl.bindRenderbuffer(gl.RENDERBUFFER, this.pickingDepthBuffer);
-            gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, pickingRes, pickingRes);
+            gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, w, h);
             gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this.pickingDepthBuffer);
+
+            this._pickW = w;
+            this._pickH = h;
         }
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, this.pickingFramebuffer);
-        gl.viewport(0, 0, pickingRes, pickingRes);
+        gl.viewport(0, 0, w, h);
         gl.clearColor(0, 0, 0, 0);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
@@ -1183,13 +1207,9 @@ export class Renderer3D {
         this.render(scene, cameraMateria, { ...options, picking: true, idMap });
 
         const pixels = new Uint8Array(4);
-        // Map x,y to picking viewport resolution
-        const px = Math.floor((x / gl.canvas.width) * pickingRes);
-        const py = Math.floor((1 - y / gl.canvas.height) * pickingRes);
-
-        gl.readPixels(px, py, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        // Correct Y for WebGL (bottom-up)
+        gl.readPixels(x, h - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        this.resize(); // Restore viewport
 
         const pickedId = pixels[0] + (pixels[1] << 8) + (pixels[2] << 16);
         return reverseIdMap.get(pickedId) || null;

--- a/verify_fix.spec.js
+++ b/verify_fix.spec.js
@@ -14,12 +14,12 @@ test('Editor should load and start without ReferenceError', async ({ page }) => 
   // Wait for the engine to initialize
   await page.waitForTimeout(3000);
 
-  // Check if CEEngine is defined and running
-  const isEngineRunning = await page.evaluate(() => {
-    return typeof window.CEEngine !== 'undefined';
+  // Check if EngineAPI is defined
+  const isEngineReady = await page.evaluate(() => {
+    return typeof window.EngineAPI !== 'undefined';
   });
 
-  expect(isEngineRunning).toBe(true);
+  expect(isEngineReady).toBe(true);
 
   // Check if there are any ReferenceErrors in the console logs
   // (Manual check of logs if needed, but the test passing CEEngine check is a good sign)


### PR DESCRIPTION
This PR addresses multiple critical bugs in the 3D game engine editor. 

Key changes:
1. **WebGL Stability**: Fixed `uniformMatrix4fv` errors in `Renderer3D.js` by scoping uniform updates to the active shader program.
2. **True 3D Gizmos**: Replaced the "2D-recycled" gizmo logic in `SceneView.js` with a proper 3D projection system where axes rotate and scale according to camera perspective. Added axis-specific scaling.
3. **Primitive Scaling**: Fixed the bug where solid cubes appeared 50x smaller than their wireframes. Standardized mesh unit sizes.
4. **New 3D Shapes**: Implemented rendering logic for Sphere, Plane, Triangle, and Capsule.
5. **Input Reliability**: Prevented keys from getting "stuck" when the window loses focus and ensured the browser context menu doesn't interrupt 3D camera navigation.
6. **Focus Feature**: Added the ability to instantly frame a selected object in the camera view using the 'F' key or a long click.
7. **UI Updates**: Added a toggle for Origin Axes and ensured the Inspector correctly triggers 3D mesh updates.

---
*PR created automatically by Jules for task [16743029603928388378](https://jules.google.com/task/16743029603928388378) started by @CarleyInteractiveStudio*