### PR TITLE
Fix 3D Gizmos Projection and Scaling

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2287,7 +2287,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
             if (!isGameView) {
-                SceneView.drawOverlay();
+                // Pass current frame matrices to eliminate drifting
+                SceneView.drawOverlay(renderer3D?.lastProjectionMatrix, renderer3D?.lastViewMatrix);
             }
             rendererInstance.end();
         };

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2208,6 +2208,10 @@ function drawCameraGizmos(renderer) {
             ctx.rotate(transform.rotation * Math.PI / 180);
         }
 
+        const r3d = window._Renderer3D;
+        const proj = r3d?.lastProjectionMatrix;
+        const view = r3d?.lastViewMatrix;
+
         if (cameraComponent.projection === 'Orthographic') {
             const size = cameraComponent.orthographicSize;
             const halfHeight = size;
@@ -2215,16 +2219,16 @@ function drawCameraGizmos(renderer) {
 
             if (is3D) {
                 const z = transform.z || 0;
-                const p1 = world3DToScreen({ x: transform.x - halfWidth, y: transform.y - halfHeight, z });
-                const p2 = world3DToScreen({ x: transform.x + halfWidth, y: transform.y - halfHeight, z });
-                const p3 = world3DToScreen({ x: transform.x + halfWidth, y: transform.y + halfHeight, z });
-                const p4 = world3DToScreen({ x: transform.x - halfWidth, y: transform.y + halfHeight, z });
-                if (p1 && p2 && p3 && p4) {
-                    ctx.beginPath();
-                    ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y);
-                    ctx.lineTo(p3.x, p3.y); ctx.lineTo(p4.x, p4.y);
-                    ctx.closePath(); ctx.stroke();
-                }
+                const p1 = { x: transform.x - halfWidth, y: transform.y - halfHeight, z };
+                const p2 = { x: transform.x + halfWidth, y: transform.y - halfHeight, z };
+                const p3 = { x: transform.x + halfWidth, y: transform.y + halfHeight, z };
+                const p4 = { x: transform.x - halfWidth, y: transform.y + halfHeight, z };
+
+                const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
+                drawLineClipped(ctx, p1, p2, clr, 2, proj, view);
+                drawLineClipped(ctx, p2, p3, clr, 2, proj, view);
+                drawLineClipped(ctx, p3, p4, clr, 2, proj, view);
+                drawLineClipped(ctx, p4, p1, clr, 2, proj, view);
             } else {
                 ctx.beginPath();
                 ctx.rect(-halfWidth, -halfHeight, halfWidth * 2, halfHeight * 2);
@@ -2278,7 +2282,7 @@ function drawCameraGizmos(renderer) {
             const f1 = projectRaw(-farW, farH, far), f2 = projectRaw(farW, farH, far), f3 = projectRaw(farW, -farH, far), f4 = projectRaw(-farW, -farH, far);
 
             const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
-            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom);
+            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom, proj, view);
 
             // Near plane
             drawL(n1, n2); drawL(n2, n3); drawL(n3, n4); drawL(n4, n1);
@@ -2552,26 +2556,26 @@ function drawLayerPlacementPreview() {
 }
 
 function getGizmoScale(center) {
-    if (!renderer || !renderer.camera) return 1.0;
+    const r3d = window._Renderer3D;
+    if (!r3d || !renderer || !renderer.camera) return 1.0;
     const cam = renderer.camera;
     const glm = window.glMatrix;
 
-    // Use distance to the camera plane for consistent screen-space scaling
-    // Cam forward vector in world space:
-    const q = glm.quat.create();
-    glm.quat.fromEuler(q, cam.rotation.x, cam.rotation.y, 0);
-    const forward = glm.vec3.fromValues(0, 0, -1);
-    glm.vec3.transformQuat(forward, forward, q);
+    // Use the actual view matrix for projected distance calculation
+    const view = r3d.lastViewMatrix;
+    const worldPos = glm.vec4.fromValues(center.x, center.y, center.z || 0, 1.0);
+    const viewPos = glm.vec4.create();
+    glm.vec4.transformMat4(viewPos, worldPos, view);
 
-    const camToObj = glm.vec3.fromValues(center.x - cam.x, center.y - cam.y, (center.z || 0) - cam.z);
-    const dist = glm.vec3.dot(camToObj, forward); // Projected distance
+    // View-space Z is the distance from camera plane.
+    // In our convention, camera looks towards -Z in view space.
+    let dist = -viewPos[2];
 
-    // Base scale on distance. 800 is a magic constant for 'normal' size at standard zoom
-    // We use Math.abs because dist could be negative if object is behind (though world3DToScreen handles that)
+    // Base scale on distance. 800 is a magic constant for 'normal' size.
     let gizmoScale = Math.abs(dist) / 800;
 
     // Minimum scale to keep it selectable, and maximum to avoid screen flooding
-    return Math.max(0.1, Math.min(gizmoScale, 5.0));
+    return Math.max(0.1, Math.min(gizmoScale, 10.0));
 }
 
 function getMateriaAxes(materia) {
@@ -2636,7 +2640,15 @@ function draw3DGizmos(materia) {
         y: transform.rotationY || 0,
         z: transform.rotationZ || 0
     };
-    const screenPos = world3DToScreen(center);
+
+    const r3d = window._Renderer3D;
+    if (!r3d) return;
+
+    // Use current rendering matrices for correct projection
+    const proj = r3d.lastProjectionMatrix;
+    const view = r3d.lastViewMatrix;
+
+    const screenPos = world3DToScreen(center, proj, view);
     if (!screenPos) return;
 
     const { ctx } = renderer;
@@ -2670,22 +2682,21 @@ function draw3DGizmos(materia) {
     const drawAxis = (worldAxis, color) => {
         const endPos = { x: center.x + worldAxis[0] * GIZMO_SIZE, y: center.y + worldAxis[1] * GIZMO_SIZE, z: center.z + worldAxis[2] * GIZMO_SIZE };
 
-        // Use drawLineClipped for axes too, in case one end is behind camera
-        const endScreen = world3DToScreen(endPos);
+        // Draw clipped line for the axis stem
+        drawLineClipped(ctx, center, endPos, color, 3, proj, view);
+
+        const endScreen = world3DToScreen(endPos, proj, view);
         if (!endScreen) return;
 
-        ctx.strokeStyle = color;
-        ctx.fillStyle = color;
-        ctx.lineWidth = 3;
-        ctx.beginPath();
-        ctx.moveTo(screenPos.x, screenPos.y);
-        ctx.lineTo(endScreen.x, endScreen.y);
-        ctx.stroke();
+        // Draw arrowhead only if it's not overlapping too much with the center
+        const screenDist = Math.hypot(endScreen.x - screenPos.x, endScreen.y - screenPos.y);
+        if (screenDist < ARROW_SIZE) return;
 
         const angle = Math.atan2(endScreen.y - screenPos.y, endScreen.x - screenPos.x);
         ctx.save();
         ctx.translate(endScreen.x, endScreen.y);
         ctx.rotate(angle);
+        ctx.fillStyle = color;
         ctx.beginPath();
         if (activeTool === 'scale') {
             ctx.rect(-ARROW_SIZE/2, -ARROW_SIZE/2, ARROW_SIZE, ARROW_SIZE);

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -60,6 +60,7 @@ export function getMouseRay3D(screenX, screenY) {
 
     // Normalize coordinates to NDC
     const x = ((screenX - rect.left) / rect.width) * 2 - 1;
+    // Standard unproject expects Y to be flipped from screen space
     const y = 1 - ((screenY - rect.top) / rect.height) * 2;
 
     const invProj = glm.mat4.create();
@@ -681,7 +682,7 @@ function drawUIGizmos(renderer, materia) {
     ctx.restore();
 }
 
-function drawGizmos(renderer, materia) {
+function drawGizmos(renderer, materia, proj = null, view = null, cw = null, ch = null) {
     if (!materia || !renderer) return;
 
     const transform = materia.getComponent(Components.Transform);
@@ -691,7 +692,7 @@ function drawGizmos(renderer, materia) {
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
 
     if (is3D) {
-        draw3DGizmos(materia);
+        draw3DGizmos(materia, proj, view, cw, ch);
         return;
     }
 
@@ -827,6 +828,7 @@ export function initialize(dependencies) {
 
                         // 1. Determine world axis vector
                         const isY = dragState.handle === 'move-y';
+                        // Use [0,-1,0] for Y to match visual UP (-Y world)
                         const localAxis = dragState.handle === 'move-x' ? [1,0,0] : (isY ? [0,-1,0] : [0,0,1]);
                         const q = glm.quat.create();
                         glm.quat.fromEuler(q, dragState.initialTransform.rotationX || 0, dragState.initialTransform.rotationY || 0, dragState.initialTransform.rotationZ || 0);
@@ -2127,18 +2129,13 @@ export function update() {
     }
 }
 
-function drawFrustumCullingGizmos() {
+function drawFrustumCullingGizmos(proj = null, view = null, cw = null, ch = null) {
     if (!SceneManager || !renderer) return;
     const scene = SceneManager.currentScene;
     if (!scene) return;
 
     const allMaterias = scene.getAllMaterias();
     const { ctx } = renderer;
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     allMaterias.forEach(materia => {
         if (!materia.isActive) return;
@@ -2181,7 +2178,7 @@ function drawFrustumCullingGizmos() {
     });
 }
 
-function drawCameraGizmos(renderer) {
+function drawCameraGizmos(renderer, proj = null, view = null, cw = null, ch = null) {
     if (!SceneManager || !renderer) return;
     const scene = SceneManager.currentScene;
     if (!scene) return;
@@ -2214,9 +2211,10 @@ function drawCameraGizmos(renderer) {
         }
 
         const r3d = window._Renderer3D;
-        const proj = r3d?.lastProjectionMatrix;
-        const view = r3d?.lastViewMatrix;
-        const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+        const _proj = proj || r3d?.lastProjectionMatrix;
+        const _view = view || r3d?.lastViewMatrix;
+        const _cw = cw || r3d?.canvas?.width;
+        const _ch = ch || r3d?.canvas?.height;
 
         if (cameraComponent.projection === 'Orthographic') {
             const size = cameraComponent.orthographicSize;
@@ -2231,10 +2229,10 @@ function drawCameraGizmos(renderer) {
                 const p4 = { x: transform.x - halfWidth, y: transform.y + halfHeight, z };
 
                 const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
-                drawLineClipped(ctx, p1, p2, clr, 2, proj, view, cw, ch);
-                drawLineClipped(ctx, p2, p3, clr, 2, proj, view, cw, ch);
-                drawLineClipped(ctx, p3, p4, clr, 2, proj, view, cw, ch);
-                drawLineClipped(ctx, p4, p1, clr, 2, proj, view, cw, ch);
+                drawLineClipped(ctx, p1, p2, clr, 2, _proj, _view, _cw, _ch);
+                drawLineClipped(ctx, p2, p3, clr, 2, _proj, _view, _cw, _ch);
+                drawLineClipped(ctx, p3, p4, clr, 2, _proj, _view, _cw, _ch);
+                drawLineClipped(ctx, p4, p1, clr, 2, _proj, _view, _cw, _ch);
             } else {
                 ctx.beginPath();
                 ctx.rect(-halfWidth, -halfHeight, halfWidth * 2, halfHeight * 2);
@@ -2275,7 +2273,7 @@ function drawCameraGizmos(renderer) {
             const project = (lx, ly, lz) => {
                 const worldPos = glm.vec3.create();
                 glm.vec3.transformQuat(worldPos, [lx, ly, -lz], q); // Cameras look towards -Z in many conventions, check ours
-                return world3DToScreen({ x: transform.x + worldPos[0], y: transform.y + worldPos[1], z: (transform.z || 0) + worldPos[2] }, proj, view, cw, ch);
+                return world3DToScreen({ x: transform.x + worldPos[0], y: transform.y + worldPos[1], z: (transform.z || 0) + worldPos[2] }, _proj, _view, _cw, _ch);
             };
 
             const projectRaw = (lx, ly, lz) => {
@@ -2288,7 +2286,7 @@ function drawCameraGizmos(renderer) {
             const f1 = projectRaw(-farW, farH, far), f2 = projectRaw(farW, farH, far), f3 = projectRaw(farW, -farH, far), f4 = projectRaw(-farW, -farH, far);
 
             const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
-            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom, proj, view, cw, ch);
+            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom, _proj, _view, _cw, _ch);
 
             // Near plane
             drawL(n1, n2); drawL(n2, n3); drawL(n3, n4); drawL(n4, n1);
@@ -2566,14 +2564,13 @@ function drawLayerPlacementPreview() {
     }
 }
 
-function getGizmoScale(center) {
+function getGizmoScale(center, customProj = null, customView = null, cw = null, ch = null) {
     const r3d = window._Renderer3D;
     if (!r3d || !renderer || !renderer.camera) return 1.0;
-    const cam = renderer.camera;
     const glm = window.glMatrix;
 
     // Use the actual view matrix for projected distance calculation
-    const view = r3d.lastViewMatrix;
+    const view = customView || r3d.lastViewMatrix;
     const worldPos = glm.vec4.fromValues(center.x, center.y, center.z || 0, 1.0);
     const viewPos = glm.vec4.create();
     glm.vec4.transformMat4(viewPos, worldPos, view);
@@ -2603,20 +2600,22 @@ function getMateriaAxes(materia) {
     glm.vec3.normalize(yAxis, yAxis);
     glm.vec3.normalize(zAxis, zAxis);
 
-    // In CE, -Y is UP in world space. We ensure the gizmo axis handle points UP.
-    glm.vec3.scale(yAxis, yAxis, -1);
+    // In CE, +Y is DOWN. Therefore, the "natural" UP direction for gizmos
+    // should be the NEGATIVE Y axis of the object.
+    const upAxis = glm.vec3.create();
+    glm.vec3.scale(upAxis, yAxis, -1);
 
-    return { x: xAxis, y: yAxis, z: zAxis };
+    return { x: xAxis, y: upAxis, z: zAxis, worldCenter: [matrix[12], matrix[13], matrix[14]] };
 }
 
 function check3DGizmoHit(canvasPos, materia) {
-    const transform = materia.getComponent(Components.Transform);
-    const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
-
     const r3d = window._Renderer3D;
     const proj = r3d?.lastProjectionMatrix;
     const view = r3d?.lastViewMatrix;
     const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
+    const axes = getMateriaAxes(materia);
+    const center = { x: axes.worldCenter[0], y: axes.worldCenter[1], z: axes.worldCenter[2] };
 
     const screenPos = world3DToScreen(center, proj, view, cw, ch);
     if (!screenPos) return null;
@@ -2625,10 +2624,7 @@ function check3DGizmoHit(canvasPos, materia) {
     const hitRadius = 25;
     const gizmoLen = 80 * gizmoScale;
 
-    const axes = getMateriaAxes(materia);
-    const glm = window.glMatrix;
-
-    const checkHandle = (worldAxis, name) => {
+    const checkHandle = (worldAxis) => {
         const axisEnd = { x: center.x + worldAxis[0] * gizmoLen, y: center.y + worldAxis[1] * gizmoLen, z: center.z + worldAxis[2] * gizmoLen };
         const screenEnd = world3DToScreen(axisEnd, proj, view, cw, ch);
         if (!screenEnd) return false;
@@ -2649,27 +2645,24 @@ function check3DGizmoHit(canvasPos, materia) {
     return null;
 }
 
-function draw3DGizmos(materia) {
-    const transform = materia.getComponent(Components.Transform);
-    const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
-    const rotation = {
-        x: transform.rotationX || 0,
-        y: transform.rotationY || 0,
-        z: transform.rotationZ || 0
-    };
-
+function draw3DGizmos(materia, customProj = null, customView = null, customCw = null, customCh = null) {
     const r3d = window._Renderer3D;
     if (!r3d) return;
 
     // Use current rendering matrices for correct projection
-    const proj = r3d.lastProjectionMatrix;
-    const view = r3d.lastViewMatrix;
+    const proj = customProj || r3d.lastProjectionMatrix;
+    const view = customView || r3d.lastViewMatrix;
+    const cw = customCw || r3d.canvas.width;
+    const ch = customCh || r3d.canvas.height;
 
-    const screenPos = world3DToScreen(center, proj, view);
+    const axes = getMateriaAxes(materia);
+    const center = { x: axes.worldCenter[0], y: axes.worldCenter[1], z: axes.worldCenter[2] };
+
+    const screenPos = world3DToScreen(center, proj, view, cw, ch);
     if (!screenPos) return;
 
     const { ctx } = renderer;
-    const gizmoScale = getGizmoScale(center);
+    const gizmoScale = getGizmoScale(center, proj, view, cw, ch);
 
     // GIZMO_SIZE is the line length in world units. It scales with distance to appear constant on screen.
     const GIZMO_SIZE = 80 * gizmoScale;
@@ -2679,30 +2672,30 @@ function draw3DGizmos(materia) {
     const C3D = window.Components3D || Components3D;
     if (!C3D) return;
 
+    const transform = materia.getComponent(Components.Transform);
     const meshRenderer = materia.getComponent(C3D.MeshRenderer3D);
     if (meshRenderer) {
         const scale = { x: transform.scale.x, y: transform.scale.y, z: transform.scale.z || 1 };
-        if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, scale, rotation);
-        else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, Math.max(scale.x, scale.y, scale.z) * 0.5, rotation);
-        else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: scale.x, z: scale.z }, rotation);
-        else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: scale.x, y: scale.y }, rotation);
-        else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, Math.max(scale.x, scale.z) * 0.25, scale.y, rotation);
+        const rotation = { x: transform.rotationX || 0, y: transform.rotationY || 0, z: transform.rotationZ || 0 };
+        if (meshRenderer.meshType === 'Cube') Gizmos.drawWireCube(ctx, center, scale, rotation, 'rgba(0, 255, 255, 0.8)', proj, view, cw, ch);
+        else if (meshRenderer.meshType === 'Sphere') Gizmos.drawWireSphere(ctx, center, Math.max(scale.x, scale.y, scale.z) * 0.5, rotation, 'rgba(0, 255, 255, 0.8)', proj, view, cw, ch);
+        else if (meshRenderer.meshType === 'Plane') Gizmos.drawWirePlane(ctx, center, { x: scale.x, z: scale.z }, rotation, 'rgba(0, 255, 255, 0.8)', proj, view, cw, ch);
+        else if (meshRenderer.meshType === 'Triangle') Gizmos.drawWireTriangle(ctx, center, { x: scale.x, y: scale.y }, rotation, 'rgba(0, 255, 255, 0.8)', proj, view, cw, ch);
+        else if (meshRenderer.meshType === 'Capsule') Gizmos.drawWireCapsule(ctx, center, Math.max(scale.x, scale.z) * 0.25, scale.y, rotation, 'rgba(0, 255, 255, 0.8)', proj, view, cw, ch);
     } else if (materia.getComponent(Components.Camera)) {
-        drawCameraGizmos(renderer);
+        drawCameraGizmos(renderer, proj, view, cw, ch);
     }
 
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-    const axes = getMateriaAxes(materia);
-
     const drawAxis = (worldAxis, color) => {
         const endPos = { x: center.x + worldAxis[0] * GIZMO_SIZE, y: center.y + worldAxis[1] * GIZMO_SIZE, z: center.z + worldAxis[2] * GIZMO_SIZE };
 
         // Draw clipped line for the axis stem
-        drawLineClipped(ctx, center, endPos, color, 3, proj, view);
+        drawLineClipped(ctx, center, endPos, color, 3, proj, view, cw, ch);
 
-        const endScreen = world3DToScreen(endPos, proj, view);
+        const endScreen = world3DToScreen(endPos, proj, view, cw, ch);
         if (!endScreen) return;
 
         // Draw arrowhead only if it's not overlapping too much with the center
@@ -2741,13 +2734,19 @@ function draw3DGizmos(materia) {
     ctx.restore();
 }
 
-export function drawOverlay() {
+export function drawOverlay(customProj = null, customView = null) {
     // This will be called from updateScene to draw grid/gizmos
     if (!renderer) return;
 
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
     const is3DActive = is3D && config.viewMode !== '2d';
+
+    // Capture matrices at the start of the overlay pass to ensure consistency
+    const r3d = window._Renderer3D;
+    const proj = customProj || r3d?.lastProjectionMatrix;
+    const view = customView || r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     if (is3D) {
         // Reset 2D transform to Screen Space for 3D-projected gizmos
@@ -2764,21 +2763,21 @@ export function drawOverlay() {
 
     // Draw gizmo for the selected object
     if (getSelectedMateria()) {
-        drawGizmos(renderer, getSelectedMateria());
+        drawGizmos(renderer, getSelectedMateria(), proj, view, cw, ch);
 
         // Project Gyzmo rectangles if in 3D
         if (is3DActive) {
             const gyzmo = getSelectedMateria().getComponent(Components.Gyzmo);
-            if (gyzmo) draw3DGyzmoRects(gyzmo);
+            if (gyzmo) draw3DGyzmoRects(gyzmo, proj, view, cw, ch);
         }
     }
 
     // Draw gizmos for all cameras in the scene
-    drawCameraGizmos(renderer);
+    drawCameraGizmos(renderer, proj, view, cw, ch);
 
     // Frustum Visualizer for Optimization Mode
     if (config.optiCameraCulling) {
-        drawFrustumCullingGizmos();
+        drawFrustumCullingGizmos(proj, view, cw, ch);
     }
 
     if (is3D) {
@@ -2788,7 +2787,7 @@ export function drawOverlay() {
 
     // Draw Icons (Audio, Camera, etc)
     if (showGizmoIcons) {
-        drawGizmoIcons();
+        drawGizmoIcons(proj, view, cw, ch);
     }
 
     if (!is3DActive) {
@@ -2796,20 +2795,20 @@ export function drawOverlay() {
         drawTileCursor();
 
         // Draw tilemap colliders
-        drawTilemapColliders();
+        drawTilemapColliders(proj, view, cw, ch);
 
         // Draw terrain colliders
-        drawTerrenoColliders();
+        drawTerrenoColliders(proj, view, cw, ch);
 
         // Draw physics colliders for selected object
-        drawPhysicsGizmos();
+        drawPhysicsGizmos(proj, view, cw, ch);
     }
 
-    draw3DPhysicsGizmos();
+    draw3DPhysicsGizmos(proj, view, cw, ch);
 
     if (!is3DActive) {
         // Draw outline for selected Tilemap
-        drawTilemapOutline();
+        drawTilemapOutline(proj, view, cw, ch);
 
         // Draw Canvas gizmos
         drawCanvasGizmos();
@@ -2925,7 +2924,7 @@ function getCachedIcon(path) {
     return img;
 }
 
-function drawGizmoIcons() {
+function drawGizmoIcons(proj = null, view = null, cw = null, ch = null) {
     if (!SceneManager || !renderer || !SceneManager.currentScene) return;
 
     const { ctx, camera } = renderer;
@@ -2933,11 +2932,6 @@ function drawGizmoIcons() {
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
     const zoom = camera.effectiveZoom;
     const allMaterias = SceneManager.currentScene.getAllMaterias();
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     const BASE_ICON_SIZE = 32;
 
@@ -3330,16 +3324,11 @@ function drawCapsulePath(ctx, width, height, direction) {
     }
 }
 
-function draw3DPhysicsGizmos() {
+function draw3DPhysicsGizmos(proj = null, view = null, cw = null, ch = null) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
     const transform = selectedMateria.getComponent(Components.Transform);
     if (!transform) return;
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     const C3D = window.Components3D || Components3D;
     if (!C3D) return;
@@ -3374,7 +3363,7 @@ function draw3DPhysicsGizmos() {
     }
 }
 
-function drawPhysicsGizmos() {
+function drawPhysicsGizmos(proj = null, view = null, cw = null, ch = null) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
 
@@ -3386,11 +3375,6 @@ function drawPhysicsGizmos() {
 
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     // Helper for 3D projected lines
     const strokeRect3D = (cx, cy, w, h, z, rot) => {
@@ -3500,7 +3484,7 @@ function drawPhysicsGizmos() {
 }
 
 
-function drawTilemapOutline() {
+function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
 
@@ -3531,11 +3515,6 @@ function drawTilemapOutline() {
 
     const layerWidth = width * cellSize.x;
     const layerHeight = height * cellSize.y;
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     if (is3D) {
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
@@ -3596,7 +3575,7 @@ function drawTilemapOutline() {
     }
 }
 
-function drawTerrenoColliders() {
+function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
 
@@ -3612,11 +3591,6 @@ function drawTerrenoColliders() {
     const { ctx, camera } = renderer;
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     const drawLine3D = (p1World, p2World) => {
         const p1 = world3DToScreen(p1World, proj, view, cw, ch);
@@ -3705,7 +3679,7 @@ function drawTerrenoColliders() {
     ctx.restore();
 }
 
-function drawTilemapColliders() {
+function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
     const selectedMateria = getSelectedMateria();
     if (!selectedMateria) return;
 
@@ -3734,11 +3708,6 @@ function drawTilemapColliders() {
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
     const { cellSize } = grid;
-
-    const r3d = window._Renderer3D;
-    const proj = r3d?.lastProjectionMatrix;
-    const view = r3d?.lastViewMatrix;
-    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
     const drawColliderRect = (rx, ry, rw, rh) => {
         if (is3D) {

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2135,6 +2135,11 @@ function drawFrustumCullingGizmos() {
     const allMaterias = scene.getAllMaterias();
     const { ctx } = renderer;
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     allMaterias.forEach(materia => {
         if (!materia.isActive) return;
         const cameraComponent = materia.getComponent(Components.Camera);
@@ -2163,8 +2168,8 @@ function drawFrustumCullingGizmos() {
                 y: transform.y,
                 z: transform.z + Math.sin(a+0.5) * lodDist
             };
-            const s1 = world3DToScreen(p1);
-            const s2 = world3DToScreen(p2);
+            const s1 = world3DToScreen(p1, proj, view, cw, ch);
+            const s2 = world3DToScreen(p2, proj, view, cw, ch);
             if (s1 && s2) {
                 ctx.beginPath();
                 ctx.moveTo(s1.x, s1.y);
@@ -2211,6 +2216,7 @@ function drawCameraGizmos(renderer) {
         const r3d = window._Renderer3D;
         const proj = r3d?.lastProjectionMatrix;
         const view = r3d?.lastViewMatrix;
+        const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
 
         if (cameraComponent.projection === 'Orthographic') {
             const size = cameraComponent.orthographicSize;
@@ -2225,10 +2231,10 @@ function drawCameraGizmos(renderer) {
                 const p4 = { x: transform.x - halfWidth, y: transform.y + halfHeight, z };
 
                 const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
-                drawLineClipped(ctx, p1, p2, clr, 2, proj, view);
-                drawLineClipped(ctx, p2, p3, clr, 2, proj, view);
-                drawLineClipped(ctx, p3, p4, clr, 2, proj, view);
-                drawLineClipped(ctx, p4, p1, clr, 2, proj, view);
+                drawLineClipped(ctx, p1, p2, clr, 2, proj, view, cw, ch);
+                drawLineClipped(ctx, p2, p3, clr, 2, proj, view, cw, ch);
+                drawLineClipped(ctx, p3, p4, clr, 2, proj, view, cw, ch);
+                drawLineClipped(ctx, p4, p1, clr, 2, proj, view, cw, ch);
             } else {
                 ctx.beginPath();
                 ctx.rect(-halfWidth, -halfHeight, halfWidth * 2, halfHeight * 2);
@@ -2269,7 +2275,7 @@ function drawCameraGizmos(renderer) {
             const project = (lx, ly, lz) => {
                 const worldPos = glm.vec3.create();
                 glm.vec3.transformQuat(worldPos, [lx, ly, -lz], q); // Cameras look towards -Z in many conventions, check ours
-                return world3DToScreen({ x: transform.x + worldPos[0], y: transform.y + worldPos[1], z: (transform.z || 0) + worldPos[2] });
+                return world3DToScreen({ x: transform.x + worldPos[0], y: transform.y + worldPos[1], z: (transform.z || 0) + worldPos[2] }, proj, view, cw, ch);
             };
 
             const projectRaw = (lx, ly, lz) => {
@@ -2282,7 +2288,7 @@ function drawCameraGizmos(renderer) {
             const f1 = projectRaw(-farW, farH, far), f2 = projectRaw(farW, farH, far), f3 = projectRaw(farW, -farH, far), f4 = projectRaw(-farW, -farH, far);
 
             const clr = isSelected ? 'rgba(255, 255, 0, 0.8)' : 'rgba(255, 255, 255, 0.4)';
-            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom, proj, view);
+            const drawL = (p1, p2) => drawLineClipped(ctx, p1, p2, clr, is3D ? 2 : 1 / renderer.camera.effectiveZoom, proj, view, cw, ch);
 
             // Near plane
             drawL(n1, n2); drawL(n2, n3); drawL(n3, n4); drawL(n4, n1);
@@ -2422,6 +2428,11 @@ function drawComponentGrids() {
 
         const gridRange = 20; // Number of cells around object
 
+        const r3d = window._Renderer3D;
+        const proj = r3d?.lastProjectionMatrix;
+        const view = r3d?.lastViewMatrix;
+        const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
         // Use local bounds for the component grid to ensure rotation is applied correctly
         const startX = -(gridRange * cellSize.x);
         const endX = (gridRange * cellSize.x);
@@ -2432,8 +2443,8 @@ function drawComponentGrids() {
         const cos = Math.cos(rad), sin = Math.sin(rad);
 
         const drawLine3D = (p1World, p2World) => {
-            const p1 = world3DToScreen(p1World);
-            const p2 = world3DToScreen(p2World);
+            const p1 = world3DToScreen(p1World, proj, view, cw, ch);
+            const p2 = world3DToScreen(p2World, proj, view, cw, ch);
             if (p1 && p2) {
                 ctx.beginPath();
                 ctx.moveTo(p1.x, p1.y);
@@ -2601,10 +2612,16 @@ function getMateriaAxes(materia) {
 function check3DGizmoHit(canvasPos, materia) {
     const transform = materia.getComponent(Components.Transform);
     const center = { x: transform.x, y: transform.y, z: transform.z || 0 };
-    const screenPos = world3DToScreen(center);
+
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
+    const screenPos = world3DToScreen(center, proj, view, cw, ch);
     if (!screenPos) return null;
 
-    const gizmoScale = getGizmoScale(center);
+    const gizmoScale = getGizmoScale(center, proj, view, cw, ch);
     const hitRadius = 25;
     const gizmoLen = 80 * gizmoScale;
 
@@ -2613,7 +2630,7 @@ function check3DGizmoHit(canvasPos, materia) {
 
     const checkHandle = (worldAxis, name) => {
         const axisEnd = { x: center.x + worldAxis[0] * gizmoLen, y: center.y + worldAxis[1] * gizmoLen, z: center.z + worldAxis[2] * gizmoLen };
-        const screenEnd = world3DToScreen(axisEnd);
+        const screenEnd = world3DToScreen(axisEnd, proj, view, cw, ch);
         if (!screenEnd) return false;
         const dx = canvasPos.x - screenEnd.x;
         const dy = canvasPos.y - screenEnd.y;
@@ -2917,6 +2934,11 @@ function drawGizmoIcons() {
     const zoom = camera.effectiveZoom;
     const allMaterias = SceneManager.currentScene.getAllMaterias();
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     const BASE_ICON_SIZE = 32;
 
     allMaterias.forEach(materia => {
@@ -2945,7 +2967,7 @@ function drawGizmoIcons() {
             if (iconImg.complete && iconImg.naturalWidth > 0) {
                 let screenPos;
                 if (is3D) {
-                    screenPos = world3DToScreen({ x: transform.x, y: transform.y, z: transform.z || 0 });
+                    screenPos = world3DToScreen({ x: transform.x, y: transform.y, z: transform.z || 0 }, proj, view, cw, ch);
                 } else {
                     screenPos = {
                         x: transform.x,
@@ -3021,6 +3043,12 @@ function draw3DGyzmoRects(gyzmo) {
     if (!transform) return;
 
     const { ctx } = renderer;
+
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
 
@@ -3050,11 +3078,11 @@ function draw3DGyzmoRects(gyzmo) {
 
         // Draw edges with clipping
         for (let i = 0; i < 4; i++) {
-            drawLineClipped(ctx, pts[i], pts[(i + 1) % 4], clr, 2);
+            drawLineClipped(ctx, pts[i], pts[(i + 1) % 4], clr, 2, proj, view, cw, ch);
         }
 
         // LENIENT FILL: only if all corners are in front of camera
-        const screenPts = pts.map(p => world3DToScreen(p));
+        const screenPts = pts.map(p => world3DToScreen(p, proj, view, cw, ch));
         if (screenPts.every(p => p !== null)) {
             ctx.globalAlpha = 0.2;
             ctx.fillStyle = clr;
@@ -3308,6 +3336,11 @@ function draw3DPhysicsGizmos() {
     const transform = selectedMateria.getComponent(Components.Transform);
     if (!transform) return;
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     const C3D = window.Components3D || Components3D;
     if (!C3D) return;
 
@@ -3326,7 +3359,7 @@ function draw3DPhysicsGizmos() {
             y: center.y + box.offset.y,
             z: center.z + box.offset.z
         };
-        Gizmos.drawWireCube(ctx, worldCenter, worldSize, 'rgba(0, 255, 0, 0.8)');
+        Gizmos.drawWireCube(ctx, worldCenter, worldSize, { x: 0, y: 0, z: 0 }, 'rgba(0, 255, 0, 0.8)', proj, view, cw, ch);
     }
 
     const sphere = selectedMateria.getComponent(C3D.SphereCollider3D);
@@ -3337,7 +3370,7 @@ function draw3DPhysicsGizmos() {
             y: center.y + sphere.offset.y,
             z: center.z + sphere.offset.z
         };
-        Gizmos.drawWireSphere(ctx, worldCenter, worldRadius, 'rgba(0, 255, 0, 0.8)');
+        Gizmos.drawWireSphere(ctx, worldCenter, worldRadius, { x: 0, y: 0, z: 0 }, 'rgba(0, 255, 0, 0.8)', proj, view, cw, ch);
     }
 }
 
@@ -3354,6 +3387,11 @@ function drawPhysicsGizmos() {
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     // Helper for 3D projected lines
     const strokeRect3D = (cx, cy, w, h, z, rot) => {
         const hw = w / 2;
@@ -3364,7 +3402,7 @@ function drawPhysicsGizmos() {
         const getPt = (lx, ly) => {
             const rx = lx * cos - ly * sin;
             const ry = lx * sin + ly * cos;
-            return world3DToScreen({ x: cx + rx, y: cy + ry, z });
+            return world3DToScreen({ x: cx + rx, y: cy + ry, z }, proj, view, cw, ch);
         };
 
         const p1 = getPt(-hw, -hh), p2 = getPt(hw, -hh), p3 = getPt(hw, hh), p4 = getPt(-hw, hh);
@@ -3494,6 +3532,11 @@ function drawTilemapOutline() {
     const layerWidth = width * cellSize.x;
     const layerHeight = height * cellSize.y;
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     if (is3D) {
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
         ctx.lineWidth = 2;
@@ -3509,7 +3552,7 @@ function drawTilemapOutline() {
             const getCorner = (lx, ly) => {
                 const rx = lx * cos - ly * sin;
                 const ry = lx * sin + ly * cos;
-                return world3DToScreen({ x: x + rx, y: y + ry, z: transform.z || 0 });
+                return world3DToScreen({ x: x + rx, y: y + ry, z: transform.z || 0 }, proj, view, cw, ch);
             };
 
             const p1 = getCorner(-hw, -hh);
@@ -3570,9 +3613,14 @@ function drawTerrenoColliders() {
     const config = getCurrentProjectConfig();
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     const drawLine3D = (p1World, p2World) => {
-        const p1 = world3DToScreen(p1World);
-        const p2 = world3DToScreen(p2World);
+        const p1 = world3DToScreen(p1World, proj, view, cw, ch);
+        const p2 = world3DToScreen(p2World, proj, view, cw, ch);
         if (p1 && p2) {
             ctx.beginPath();
             ctx.moveTo(p1.x, p1.y);
@@ -3687,6 +3735,11 @@ function drawTilemapColliders() {
     const is3D = config.rendererMode === '3d-mode' || config.rendererMode === 'hybrid-3d' || config.rendererMode === 'anime-3d';
     const { cellSize } = grid;
 
+    const r3d = window._Renderer3D;
+    const proj = r3d?.lastProjectionMatrix;
+    const view = r3d?.lastViewMatrix;
+    const cw = r3d?.canvas?.width, ch = r3d?.canvas?.height;
+
     const drawColliderRect = (rx, ry, rw, rh) => {
         if (is3D) {
             // Tiles in Tilemap are local to the Tilemap center.
@@ -3697,7 +3750,7 @@ function drawTilemapColliders() {
             const getPt = (lx, ly) => {
                 const rx_loc = lx * cos - ly * sin;
                 const ry_loc = lx * sin + ly * cos;
-                return world3DToScreen({ x: transform.x + rx_loc, y: transform.y + ry_loc, z: transform.z || 0 });
+                return world3DToScreen({ x: transform.x + rx_loc, y: transform.y + ry_loc, z: transform.z || 0 }, proj, view, cw, ch);
             };
 
             const p1 = getPt(rx, ry), p2 = getPt(rx + rw, ry), p3 = getPt(rx + rw, ry + rh), p4 = getPt(rx, ry + rh);

--- a/js/engine/MathUtils.js
+++ b/js/engine/MathUtils.js
@@ -208,23 +208,34 @@ export function cos(degrees) { return Math.cos(degrees * Math.PI / 180); }
 
 /**
  * Converts a 3D world position to 2D screen coordinates.
+ * @param {{x:number, y:number, z:number}} worldPos
+ * @param {mat4} [customProj] Optional projection matrix.
+ * @param {mat4} [customView] Optional view matrix.
  */
-export function world3DToScreen(worldPos) {
+export function world3DToScreen(worldPos, customProj = null, customView = null) {
     const r3d = window._Renderer3D;
     const glm = window.glMatrix;
-    if (!r3d || !r3d.lastProjectionMatrix || !r3d.lastViewMatrix || !glm) return null;
+    const proj = customProj || r3d?.lastProjectionMatrix;
+    const view = customView || r3d?.lastViewMatrix;
+
+    if (!proj || !view || !glm) return null;
 
     const canvas = r3d.canvas;
     const worldVec = glm.vec4.fromValues(worldPos.x, worldPos.y, worldPos.z || 0, 1.0);
     const mvp = glm.mat4.create();
-    glm.mat4.multiply(mvp, r3d.lastProjectionMatrix, r3d.lastViewMatrix);
+    glm.mat4.multiply(mvp, proj, view);
 
     const clipPos = glm.vec4.create();
     glm.vec4.transformMat4(clipPos, worldVec, mvp);
 
-    if (clipPos[3] < 0.001) return null;
+    // Near plane clipping
+    if (clipPos[3] < 0.01) return null;
 
     const ndc = [clipPos[0] / clipPos[3], clipPos[1] / clipPos[3], clipPos[2] / clipPos[3]];
+
+    // Safety check for extreme NDC values to prevent erratic drawing
+    if (Math.abs(ndc[0]) > 10.0 || Math.abs(ndc[1]) > 10.0) return null;
+
     const width = canvas.width, height = canvas.height;
 
     // Corrected for Y-flipped projection matrix:
@@ -240,13 +251,16 @@ export function world3DToScreen(worldPos) {
 /**
  * Draws a 3D world line with clipping against the near plane.
  */
-export function drawLineClipped(ctx, p1, p2, color, width = 1) {
+export function drawLineClipped(ctx, p1, p2, color, width = 1, customProj = null, customView = null) {
     const r3d = window._Renderer3D;
     const glm = window.glMatrix;
-    if (!r3d || !r3d.lastProjectionMatrix || !r3d.lastViewMatrix || !glm) return;
+    const proj = customProj || r3d?.lastProjectionMatrix;
+    const view = customView || r3d?.lastViewMatrix;
+
+    if (!proj || !view || !glm) return;
 
     const mvp = glm.mat4.create();
-    glm.mat4.multiply(mvp, r3d.lastProjectionMatrix, r3d.lastViewMatrix);
+    glm.mat4.multiply(mvp, proj, view);
 
     const v1 = glm.vec4.fromValues(p1.x, p1.y, p1.z || 0, 1.0);
     const v2 = glm.vec4.fromValues(p2.x, p2.y, p2.z || 0, 1.0);
@@ -255,7 +269,7 @@ export function drawLineClipped(ctx, p1, p2, color, width = 1) {
     glm.vec4.transformMat4(c1, v1, mvp);
     glm.vec4.transformMat4(c2, v2, mvp);
 
-    const wNear = 0.1;
+    const wNear = 0.01;
     if (c1[3] < wNear && c2[3] < wNear) return;
 
     if (c1[3] < wNear) {
@@ -267,9 +281,13 @@ export function drawLineClipped(ctx, p1, p2, color, width = 1) {
     }
 
     const w = r3d.canvas.width, h = r3d.canvas.height;
+
     // Corrected for Y-flipped projection (NDC -1 is TOP)
     const s1 = { x: (c1[0]/c1[3] * 0.5 + 0.5) * w, y: (c1[1]/c1[3] * 0.5 + 0.5) * h };
     const s2 = { x: (c2[0]/c2[3] * 0.5 + 0.5) * w, y: (c2[1]/c2[3] * 0.5 + 0.5) * h };
+
+    // Final sanity check
+    if (isNaN(s1.x) || isNaN(s1.y) || isNaN(s2.x) || isNaN(s2.y)) return;
 
     ctx.strokeStyle = color;
     ctx.lineWidth = width;

--- a/js/engine/MathUtils.js
+++ b/js/engine/MathUtils.js
@@ -3,13 +3,8 @@
  * Includes vector operations, matrix transformations, and collision detection algorithms.
  */
 
-// Vector operations can be added here if needed.
-
 /**
  * Calculates the world-space vertices of an object's Oriented Bounding Box (OOB).
- * @param {Materia} materia The game object.
- * @param {{x:number, y:number}} [explicitPosition] Optional explicit world position.
- * @returns {Array<{x: number, y: number}>|null} An array of 4 vertex points or null if not applicable.
  */
 export function getOOB(materia, explicitPosition = null) {
     const transform = materia.getComponentByName('Transform');
@@ -58,7 +53,7 @@ export function getOOB(materia, explicitPosition = null) {
             maxX = Math.max(maxX, chunk.x + terreno.chunkSize); maxY = Math.max(maxY, chunk.y + terreno.chunkSize);
         });
         w = maxX - minX; h = maxY - minY;
-        pivotX = -minX / (w || 1); pivotY = -minRow / (h || 1);
+        pivotX = -minX / (w || 1); pivotY = -minY / (h || 1);
     } else if (gyzmo && gyzmo.layers && gyzmo.layers.length > 0) {
         let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
         for (const l of gyzmo.layers) {
@@ -208,11 +203,8 @@ export function cos(degrees) { return Math.cos(degrees * Math.PI / 180); }
 
 /**
  * Converts a 3D world position to 2D screen coordinates.
- * @param {{x:number, y:number, z:number}} worldPos
- * @param {mat4} [customProj] Optional projection matrix.
- * @param {mat4} [customView] Optional view matrix.
  */
-export function world3DToScreen(worldPos, customProj = null, customView = null) {
+export function world3DToScreen(worldPos, customProj = null, customView = null, canvasWidth = null, canvasHeight = null) {
     const r3d = window._Renderer3D;
     const glm = window.glMatrix;
     const proj = customProj || r3d?.lastProjectionMatrix;
@@ -220,7 +212,9 @@ export function world3DToScreen(worldPos, customProj = null, customView = null) 
 
     if (!proj || !view || !glm) return null;
 
-    const canvas = r3d.canvas;
+    const width = canvasWidth ?? r3d?.canvas?.width ?? 800;
+    const height = canvasHeight ?? r3d?.canvas?.height ?? 600;
+
     const worldVec = glm.vec4.fromValues(worldPos.x, worldPos.y, worldPos.z || 0, 1.0);
     const mvp = glm.mat4.create();
     glm.mat4.multiply(mvp, proj, view);
@@ -228,20 +222,16 @@ export function world3DToScreen(worldPos, customProj = null, customView = null) 
     const clipPos = glm.vec4.create();
     glm.vec4.transformMat4(clipPos, worldVec, mvp);
 
-    // Near plane clipping
     if (clipPos[3] < 0.01) return null;
 
     const ndc = [clipPos[0] / clipPos[3], clipPos[1] / clipPos[3], clipPos[2] / clipPos[3]];
-
-    // Safety check for extreme NDC values to prevent erratic drawing
     if (Math.abs(ndc[0]) > 10.0 || Math.abs(ndc[1]) > 10.0) return null;
 
-    const width = canvas.width, height = canvas.height;
-
-    // Corrected for Y-flipped projection matrix:
-    // In our Renderer3D, we use mat4.scale(proj, [1, -1, 1]), which flips NDC Y.
-    // Mapping NDC Y [-1, 1] to screen [0, height] where screen 0 is TOP:
-    // With Y-flipped projection, NDC -1 is TOP.
+    // NDC Y mapping for CE: World UP is -Y, World DOWN is +Y.
+    // Our Renderer3D uses a flipped projection matrix (scale [1, -1, 1]).
+    // This maps World-UP to NDC -1 and World-DOWN to NDC +1.
+    // Screen: TOP is 0. So NDC -1 (UP) -> 0.
+    // Formula: (ndcY * 0.5 + 0.5) * height
     return {
         x: (ndc[0] * 0.5 + 0.5) * width,
         y: (ndc[1] * 0.5 + 0.5) * height
@@ -251,13 +241,16 @@ export function world3DToScreen(worldPos, customProj = null, customView = null) 
 /**
  * Draws a 3D world line with clipping against the near plane.
  */
-export function drawLineClipped(ctx, p1, p2, color, width = 1, customProj = null, customView = null) {
+export function drawLineClipped(ctx, p1, p2, color, width = 1, customProj = null, customView = null, canvasWidth = null, canvasHeight = null) {
     const r3d = window._Renderer3D;
     const glm = window.glMatrix;
     const proj = customProj || r3d?.lastProjectionMatrix;
     const view = customView || r3d?.lastViewMatrix;
 
     if (!proj || !view || !glm) return;
+
+    const w = canvasWidth ?? r3d?.canvas?.width ?? 800;
+    const h = canvasHeight ?? r3d?.canvas?.height ?? 600;
 
     const mvp = glm.mat4.create();
     glm.mat4.multiply(mvp, proj, view);
@@ -280,13 +273,9 @@ export function drawLineClipped(ctx, p1, p2, color, width = 1, customProj = null
         glm.vec4.lerp(c2, c2, c1, t);
     }
 
-    const w = r3d.canvas.width, h = r3d.canvas.height;
-
-    // Corrected for Y-flipped projection (NDC -1 is TOP)
     const s1 = { x: (c1[0]/c1[3] * 0.5 + 0.5) * w, y: (c1[1]/c1[3] * 0.5 + 0.5) * h };
     const s2 = { x: (c2[0]/c2[3] * 0.5 + 0.5) * w, y: (c2[1]/c2[3] * 0.5 + 0.5) * h };
 
-    // Final sanity check
     if (isNaN(s1.x) || isNaN(s1.y) || isNaN(s2.x) || isNaN(s2.y)) return;
 
     ctx.strokeStyle = color;

--- a/js/engine/Renderer3D.js
+++ b/js/engine/Renderer3D.js
@@ -459,12 +459,19 @@ export class Renderer3D {
         gl.vertexAttribPointer(posLoc, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(posLoc);
 
-        const yModel = mat4.create();
-        mat4.scale(yModel, yModel, [0.4, 100000, 0.4]);
-        gl.uniformMatrix4fv(modelLoc, false, yModel);
-        gl.uniform4f(colorLoc, 0, 1, 0, 1);
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.buffers.cubeIdx);
-        gl.drawElements(gl.TRIANGLES, 36, gl.UNSIGNED_SHORT, 0);
+        // Finite axes at origin
+        const drawAxis = (scale, color) => {
+            const m = mat4.create();
+            mat4.scale(m, m, scale);
+            gl.uniformMatrix4fv(modelLoc, false, m);
+            gl.uniform4f(colorLoc, color[0], color[1], color[2], 1);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.buffers.cubeIdx);
+            gl.drawElements(gl.TRIANGLES, 36, gl.UNSIGNED_SHORT, 0);
+        };
+
+        drawAxis([0.2, 500, 0.2], [0, 1, 0]); // Y (Up/Down)
+        drawAxis([500, 0.2, 0.2], [1, 0, 0]); // X
+        drawAxis([0.2, 0.2, 500], [0, 0, 1]); // Z
     }
 
     drawScene(scene, cameraMateria = null) {


### PR DESCRIPTION
This change fixes critical issues with the 3D editor gizmos (transformation handles and camera wireframes). Previously, gizmos would "float" or drift away from objects when the editor camera moved because they were using inconsistent or stale projection matrices from the engine's global state. Additionally, gizmo arrowheads would scale incorrectly at distances, often covering the entire screen.

Key improvements:
1. Matrix Consistency: Gizmos now capture and use the exact projection and view matrices used by the 3D renderer in the same frame.
2. Robust Scaling: The gizmo scaling logic now correctly accounts for perspective depth using the view matrix.
3. Projection Safety: Added clipping and NDC validation in MathUtils to prevent coordinate "explosions" for points behind or very near the camera.
4. Visual Polish: Added finite origin axes and handle-occlusion logic for a cleaner editing experience.

---
*PR created automatically by Jules for task [5754638485763109811](https://jules.google.com/task/5754638485763109811) started by @CarleyInteractiveStudio*