### PR TITLE
Fix Tilemap Y-UP Rendering and Migration Loop

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -1395,8 +1395,9 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log("Configuracion del proyecto cargada:", currentProjectConfig);
 
             // --- Coordinate System Migration (+Y UP) ---
-            // Force re-migration if version is older than 2.0.3 to fix inversions
+            // Force re-migration if version is older than 2.0.6 to fix inversions
             const compareVersions = (v1, v2) => {
+                if (!v1 || typeof v1 !== 'string') return -1;
                 const parts1 = v1.split('.').map(Number);
                 const parts2 = v2.split('.').map(Number);
                 for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
@@ -1410,7 +1411,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const needsMigration = currentProjectConfig.coordinateSystem !== 'Y-UP' ||
                                  (!currentProjectConfig.engineVersion) ||
-                                 (compareVersions(currentProjectConfig.engineVersion, '2.0.3') < 0);
+                                 (compareVersions(currentProjectConfig.engineVersion, '2.0.6') < 0);
 
             if (needsMigration) {
                 const projectName = new URLSearchParams(window.location.search).get('project');
@@ -1425,7 +1426,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             const success = await AutoReparator.runMigration(projectsDirHandle, currentProjectConfig);
                             if (success) {
                                 // Update version to avoid re-migration
-                                currentProjectConfig.engineVersion = '2.0.3';
+                                currentProjectConfig.engineVersion = '2.0.6';
                                 currentProjectConfig.coordinateSystem = 'Y-UP';
 
                                 try {
@@ -1474,7 +1475,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 appVersion: '1.0.0',
                 projectType: '2d', // New: '2d' or '3d'
                 coordinateSystem: 'Y-UP',
-                engineVersion: '2.0.3',
+                engineVersion: '2.0.6',
                 maxFps: 60,
                 minFps: 30,
                 iconPath: '',

--- a/js/editor.js
+++ b/js/editor.js
@@ -1407,8 +1407,15 @@ document.addEventListener('DOMContentLoaded', () => {
                         async () => {
                             const success = await AutoReparator.runMigration(projectsDirHandle, currentProjectConfig);
                             if (success) {
-                                if (typeof saveProjectConfigFromModule === 'function') {
-                                    await saveProjectConfigFromModule(false);
+                                try {
+                                    const projectName = new URLSearchParams(window.location.search).get('project');
+                                    const projectHandle = await projectsDirHandle.getDirectoryHandle(projectName);
+                                    const configFileHandle = await projectHandle.getFileHandle('project.ceconfig', { create: true });
+                                    const writable = await configFileHandle.createWritable();
+                                    await writable.write(JSON.stringify(currentProjectConfig, null, 2));
+                                    await writable.close();
+                                } catch (e) {
+                                    console.error("[Migration] Error saving project config directly:", e);
                                 }
                                 showNotificationDialog('Éxito', 'Proyecto migrado correctamente. Por favor, reinicia el editor.');
                                 setTimeout(() => window.location.reload(), 2000);

--- a/js/editor.js
+++ b/js/editor.js
@@ -1395,7 +1395,7 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log("Configuracion del proyecto cargada:", currentProjectConfig);
 
             // --- Coordinate System Migration (+Y UP) ---
-            // Force re-migration if version is older than 2.0.6 to fix inversions
+            // Force re-migration if version is older than 2.0.7 to fix inversions
             const compareVersions = (v1, v2) => {
                 if (!v1 || typeof v1 !== 'string') return -1;
                 const parts1 = v1.split('.').map(Number);
@@ -1411,7 +1411,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const needsMigration = currentProjectConfig.coordinateSystem !== 'Y-UP' ||
                                  (!currentProjectConfig.engineVersion) ||
-                                 (compareVersions(currentProjectConfig.engineVersion, '2.0.6') < 0);
+                                 (compareVersions(currentProjectConfig.engineVersion, '2.0.7') < 0);
 
             if (needsMigration) {
                 const projectName = new URLSearchParams(window.location.search).get('project');
@@ -1426,7 +1426,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             const success = await AutoReparator.runMigration(projectsDirHandle, currentProjectConfig);
                             if (success) {
                                 // Update version to avoid re-migration
-                                currentProjectConfig.engineVersion = '2.0.6';
+                                currentProjectConfig.engineVersion = '2.0.7';
                                 currentProjectConfig.coordinateSystem = 'Y-UP';
 
                                 try {
@@ -1475,7 +1475,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 appVersion: '1.0.0',
                 projectType: '2d', // New: '2d' or '3d'
                 coordinateSystem: 'Y-UP',
-                engineVersion: '2.0.6',
+                engineVersion: '2.0.7',
                 maxFps: 60,
                 minFps: 30,
                 iconPath: '',

--- a/js/editor.js
+++ b/js/editor.js
@@ -1395,7 +1395,11 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log("Configuracion del proyecto cargada:", currentProjectConfig);
 
             // --- Coordinate System Migration (+Y UP) ---
-            if (currentProjectConfig.coordinateSystem !== 'Y-UP') {
+            // Force re-migration if version is older than 2.0.2 to fix Tilemap inversions
+            const needsMigration = currentProjectConfig.coordinateSystem !== 'Y-UP' ||
+                                 (currentProjectConfig.engineVersion && parseFloat(currentProjectConfig.engineVersion) < 2.02);
+
+            if (needsMigration) {
                 const projectName = new URLSearchParams(window.location.search).get('project');
 
                 await new Promise(resolve => {
@@ -1407,6 +1411,10 @@ document.addEventListener('DOMContentLoaded', () => {
                         async () => {
                             const success = await AutoReparator.runMigration(projectsDirHandle, currentProjectConfig);
                             if (success) {
+                                // Update version to avoid re-migration
+                                currentProjectConfig.engineVersion = '2.0.2';
+                                currentProjectConfig.coordinateSystem = 'Y-UP';
+
                                 try {
                                     const projectName = new URLSearchParams(window.location.search).get('project');
                                     const projectHandle = await projectsDirHandle.getDirectoryHandle(projectName);

--- a/js/editor.js
+++ b/js/editor.js
@@ -1395,9 +1395,22 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log("Configuracion del proyecto cargada:", currentProjectConfig);
 
             // --- Coordinate System Migration (+Y UP) ---
-            // Force re-migration if version is older than 2.0.2 to fix Tilemap inversions
+            // Force re-migration if version is older than 2.0.3 to fix inversions
+            const compareVersions = (v1, v2) => {
+                const parts1 = v1.split('.').map(Number);
+                const parts2 = v2.split('.').map(Number);
+                for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+                    const p1 = parts1[i] || 0;
+                    const p2 = parts2[i] || 0;
+                    if (p1 < p2) return -1;
+                    if (p1 > p2) return 1;
+                }
+                return 0;
+            };
+
             const needsMigration = currentProjectConfig.coordinateSystem !== 'Y-UP' ||
-                                 (currentProjectConfig.engineVersion && parseFloat(currentProjectConfig.engineVersion) < 2.02);
+                                 (!currentProjectConfig.engineVersion) ||
+                                 (compareVersions(currentProjectConfig.engineVersion, '2.0.3') < 0);
 
             if (needsMigration) {
                 const projectName = new URLSearchParams(window.location.search).get('project');
@@ -1412,7 +1425,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             const success = await AutoReparator.runMigration(projectsDirHandle, currentProjectConfig);
                             if (success) {
                                 // Update version to avoid re-migration
-                                currentProjectConfig.engineVersion = '2.0.2';
+                                currentProjectConfig.engineVersion = '2.0.3';
                                 currentProjectConfig.coordinateSystem = 'Y-UP';
 
                                 try {
@@ -1461,7 +1474,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 appVersion: '1.0.0',
                 projectType: '2d', // New: '2d' or '3d'
                 coordinateSystem: 'Y-UP',
-                engineVersion: '2.0.0',
+                engineVersion: '2.0.3',
                 maxFps: 60,
                 minFps: 30,
                 iconPath: '',

--- a/js/editor/AutoReparator.js
+++ b/js/editor/AutoReparator.js
@@ -99,7 +99,7 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
 
         // Actualizar configuración del proyecto
         currentProjectConfig.coordinateSystem = 'Y-UP';
-        currentProjectConfig.engineVersion = '2.0.6';
+        currentProjectConfig.engineVersion = '2.0.7';
 
         // El guardado del config se hará en editor.js tras llamar a esta función
 

--- a/js/editor/AutoReparator.js
+++ b/js/editor/AutoReparator.js
@@ -95,7 +95,7 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
 
         // Actualizar configuración del proyecto
         currentProjectConfig.coordinateSystem = 'Y-UP';
-        currentProjectConfig.engineVersion = '2.0.0';
+        currentProjectConfig.engineVersion = '2.0.2';
 
         // El guardado del config se hará en editor.js tras llamar a esta función
 

--- a/js/editor/AutoReparator.js
+++ b/js/editor/AutoReparator.js
@@ -77,9 +77,13 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
                         }
                     } else if (ley.type === 'PointLight2D' || ley.type === 'SpotLight2D') {
                         if (props.offset) props.offset.y *= -1;
+                    } else if (ley.type === 'Tilemap') {
+                        if (props.layers) {
+                            props.layers.forEach(layer => {
+                                if (layer.position) layer.position.y *= -1;
+                            });
+                        }
                     }
-                    // Tilemap layers don't need Y inversion because the new Renderer handles it relative to the materia center
-                    // which is already being moved to the correct Y position.
                 });
             }
             if (m.children) {

--- a/js/editor/AutoReparator.js
+++ b/js/editor/AutoReparator.js
@@ -60,28 +60,32 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
         }
 
         function migrateMateria(m) {
+            const isOldSystem = currentProjectConfig.coordinateSystem !== 'Y-UP';
+
             if (m.leyes) {
                 m.leyes.forEach(ley => {
                     const props = ley.properties;
                     if (!props) return;
 
-                    if (ley.type === 'Transform') {
-                        if (props.localPosition) props.localPosition.y *= -1;
-                    } else if (ley.type === 'BoxCollider2D' || ley.type === 'CircleCollider2D' || ley.type === 'CapsuleCollider2D' || ley.type === 'PolygonCollider2D' || ley.type === 'LineCollider2D') {
-                        if (props.offset) props.offset.y *= -1;
-                        if (ley.type === 'PolygonCollider2D' && props.vertices) {
-                            props.vertices.forEach(v => v.y *= -1);
-                        }
-                        if (ley.type === 'LineCollider2D' && props.points) {
-                            props.points.forEach(p => p.y *= -1);
-                        }
-                    } else if (ley.type === 'PointLight2D' || ley.type === 'SpotLight2D') {
-                        if (props.offset) props.offset.y *= -1;
-                    } else if (ley.type === 'Tilemap') {
-                        if (props.layers) {
-                            props.layers.forEach(layer => {
-                                if (layer.position) layer.position.y *= -1;
-                            });
+                    if (isOldSystem) {
+                        if (ley.type === 'Transform') {
+                            if (props.localPosition) props.localPosition.y *= -1;
+                        } else if (ley.type === 'BoxCollider2D' || ley.type === 'CircleCollider2D' || ley.type === 'CapsuleCollider2D' || ley.type === 'PolygonCollider2D' || ley.type === 'LineCollider2D') {
+                            if (props.offset) props.offset.y *= -1;
+                            if (ley.type === 'PolygonCollider2D' && props.vertices) {
+                                props.vertices.forEach(v => v.y *= -1);
+                            }
+                            if (ley.type === 'LineCollider2D' && props.points) {
+                                props.points.forEach(p => p.y *= -1);
+                            }
+                        } else if (ley.type === 'PointLight2D' || ley.type === 'SpotLight2D') {
+                            if (props.offset) props.offset.y *= -1;
+                        } else if (ley.type === 'Tilemap') {
+                            if (props.layers) {
+                                props.layers.forEach(layer => {
+                                    if (layer.position) layer.position.y *= -1;
+                                });
+                            }
                         }
                     }
                 });
@@ -95,7 +99,7 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
 
         // Actualizar configuración del proyecto
         currentProjectConfig.coordinateSystem = 'Y-UP';
-        currentProjectConfig.engineVersion = '2.0.3';
+        currentProjectConfig.engineVersion = '2.0.6';
 
         // El guardado del config se hará en editor.js tras llamar a esta función
 

--- a/js/editor/AutoReparator.js
+++ b/js/editor/AutoReparator.js
@@ -95,7 +95,7 @@ export async function runMigration(projectsDirHandle, currentProjectConfig) {
 
         // Actualizar configuración del proyecto
         currentProjectConfig.coordinateSystem = 'Y-UP';
-        currentProjectConfig.engineVersion = '2.0.2';
+        currentProjectConfig.engineVersion = '2.0.3';
 
         // El guardado del config se hará en editor.js tras llamar a esta función
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -3754,7 +3754,13 @@ function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        ctx.scale(transform.scale.x, -transform.scale.y);
+        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js
+        // If we apply scale(1, -1) again here, we negate it.
+        // However, SceneView debug drawing usually happens outside the primary draw loop or needs consistent logic.
+        // Actually, the Renderer.js beginWorld applies scale(zoom, -zoom).
+        // If we want to draw collider RECTS that are defined in +Y UP world space,
+        // we should just use world coordinates.
+        ctx.scale(transform.scale.x, transform.scale.y);
     }
 
     ctx.strokeStyle = 'rgba(0, 255, 0, 0.8)';
@@ -3873,7 +3879,7 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        ctx.scale(transform.scale.x, -transform.scale.y);
+        ctx.scale(transform.scale.x, transform.scale.y);
     }
 
     ctx.strokeStyle = 'rgba(0, 255, 0, 0.7)';

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2448,6 +2448,9 @@ function drawTileCursor() {
 
             const drawCursor = (c, r) => {
                 // We draw in +Y UP world space directly
+                // In +Y UP world context, strokeRect(x,y,w,h) draws from Y downwards?
+                // Actually, if we are in world context (scale(1, -1)), it draws from Y UPWARDS.
+                // Because Renderer.js beginWorld: scale(zoom, -zoom).
                 const tx = layerTopLeftX + c * cellSize.x;
                 const ty = layerTopY - (r + 1) * cellSize.y;
                 ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
@@ -3680,7 +3683,6 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         ctx.save();
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        ctx.scale(1, -1);
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
         ctx.lineWidth = 2 / camera.effectiveZoom;
@@ -3740,9 +3742,7 @@ function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js.
-        // We un-flip it locally to draw in standard Y-down coordinates.
-        ctx.scale(transform.scale.x, -transform.scale.y);
+        ctx.scale(transform.scale.x, transform.scale.y);
     }
 
     ctx.strokeStyle = 'rgba(0, 255, 0, 0.8)';

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2419,12 +2419,12 @@ function drawTileCursor() {
     const mousePos = InputManager.getMousePositionInCanvas();
     const worldMouse = screenToWorld(mousePos.x, mousePos.y);
 
-    // Transform world mouse to tilemap local space (accounting for rotation)
+    // Transform world mouse to tilemap local space (accounting for rotation and scale)
     const relX = worldMouse.x - transform.x;
     const relY = worldMouse.y - transform.y;
     const rad = -transform.rotation * Math.PI / 180;
-    const localMouseX = relX * Math.cos(rad) - relY * Math.sin(rad);
-    const localMouseY = relX * Math.sin(rad) + relY * Math.cos(rad);
+    const localMouseX = (relX * Math.cos(rad) - relY * Math.sin(rad)) / (transform.scale.x || 1);
+    const localMouseY = (relX * Math.sin(rad) + relY * Math.cos(rad)) / (transform.scale.y || 1);
 
     const layerWidth = width * cellSize.x;
     const layerHeight = height * cellSize.y;
@@ -2434,11 +2434,11 @@ function drawTileCursor() {
         const layerOffsetY = layer.position.y * layerHeight;
 
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY + layerHeight / 2;
+        const layerTopY = layerOffsetY + layerHeight / 2;
 
         const col = Math.floor((localMouseX - layerTopLeftX) / cellSize.x);
-        // localMouseY is world +Y UP. Row 0 is at layerTopLeftY.
-        const row = Math.floor((layerTopLeftY - localMouseY) / cellSize.y);
+        // localMouseY is world +Y UP. Row 0 is at layerTopY.
+        const row = Math.floor((layerTopY - localMouseY) / cellSize.y);
 
         if (col >= 0 && col < width && row >= 0 && row < height) {
             ctx.save();
@@ -2447,9 +2447,9 @@ function drawTileCursor() {
             ctx.lineWidth = 2 / renderer.camera.effectiveZoom;
 
             const drawCursor = (c, r) => {
+                // We draw in +Y UP world space directly
                 const tx = layerTopLeftX + c * cellSize.x;
-                // In local Y-DOWN context, Row 0 is at Top Y = - (layerHeight / 2) - layerOffsetY
-                const ty = (r * cellSize.y) - (layerHeight / 2) - layerOffsetY;
+                const ty = layerTopY - (r + 1) * cellSize.y;
                 ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
                 ctx.strokeRect(tx, ty, cellSize.x, cellSize.y);
             };
@@ -3688,9 +3688,8 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         for (const layer of tilemap.layers) {
             const offsetX = layer.position.x * layerWidth;
             const offsetY = layer.position.y * layerHeight;
-            // Draw layer bounds in local Y-down space
-            const dy = - (layerHeight / 2) - offsetY;
-            ctx.strokeRect(offsetX - layerWidth / 2, dy, layerWidth, layerHeight);
+            // Draw layer bounds in +Y UP space
+            ctx.strokeRect(offsetX - layerWidth / 2, offsetY - layerHeight / 2, layerWidth, layerHeight);
         }
         ctx.restore();
     }
@@ -3882,12 +3881,13 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
         const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
+        const layerTopY = layerOffsetY + layerHeight / 2;
+
         for (const rect of rects) {
             // rect coordinates are relative to the Tilemap center (local)
             const rectX = layerTopLeftX + rect.col * cellSize.x;
-            // In a locally-unflipped context (Y-Down), Row 0 is at visual Top.
-            // Local Top Y of map = - (layerHeight / 2) - layerOffsetY
-            const rectY = (rect.row * cellSize.y) - (layerHeight / 2) - layerOffsetY;
+            // Row 0 is Top (+Y). Bottom Y of rect = TopY - (row + height) * cellSize
+            const rectY = layerTopY - (rect.row + rect.height) * cellSize.y;
             const rectWidth = rect.width * cellSize.x;
             const rectHeight = rect.height * cellSize.y;
             drawColliderRect(rectX, rectY, rectWidth, rectHeight);
@@ -3979,8 +3979,8 @@ function paintTile(event) {
     const relX = worldMouse.x - transform.x;
     const relY = worldMouse.y - transform.y;
     const rad = -transform.rotation * Math.PI / 180;
-    const localMouseX = relX * Math.cos(rad) - relY * Math.sin(rad);
-    const localMouseY = relX * Math.sin(rad) + relY * Math.cos(rad);
+    const localMouseX = (relX * Math.cos(rad) - relY * Math.sin(rad)) / (transform.scale.x || 1);
+    const localMouseY = (relX * Math.sin(rad) + relY * Math.cos(rad)) / (transform.scale.y || 1);
 
     const layerWidth = width * cellSize.x;
     const layerHeight = height * cellSize.y;
@@ -4028,10 +4028,10 @@ function paintTile(event) {
         const layerOffsetX = l.position.x * layerWidth;
         const layerOffsetY = l.position.y * layerHeight;
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY + layerHeight / 2;
+        const layerTopY = layerOffsetY + layerHeight / 2;
         return {
             col: Math.floor((localMouseX - layerTopLeftX) / cellSize.x),
-            row: Math.floor((layerTopLeftY - localMouseY) / cellSize.y)
+            row: Math.floor((layerTopY - localMouseY) / cellSize.y)
         };
     };
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2433,10 +2433,10 @@ function drawTileCursor() {
         const layerOffsetY = layer.position.y * layerHeight;
 
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY + layerHeight / 2;
+        const layerTopLeftY = - (layerOffsetY + layerHeight / 2);
 
-        const col = Math.floor((localMouseX - (layerOffsetX - layerWidth / 2)) / cellSize.x);
-        const row = Math.floor((layerTopLeftY - localMouseY) / cellSize.y);
+        const col = Math.floor((localMouseX - layerTopLeftX) / cellSize.x);
+        const row = Math.floor((localMouseY - layerTopLeftY) / cellSize.y);
 
         if (col >= 0 && col < width && row >= 0 && row < height) {
             ctx.save();
@@ -2446,7 +2446,7 @@ function drawTileCursor() {
 
             const drawCursor = (c, r) => {
                 const tx = layerTopLeftX + c * cellSize.x;
-                const ty = layerTopLeftY - (r + 1) * cellSize.y;
+                const ty = layerTopLeftY + r * cellSize.y;
                 ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
                 ctx.strokeRect(tx, ty, cellSize.x, cellSize.y);
             };
@@ -3677,6 +3677,7 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         ctx.save();
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
+        ctx.scale(1, -1);
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
         ctx.lineWidth = 2 / camera.effectiveZoom;
@@ -3684,7 +3685,7 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         for (const layer of tilemap.layers) {
             const offsetX = layer.position.x * layerWidth;
             const offsetY = layer.position.y * layerHeight;
-            // Draw layer bounds in world +Y UP space
+            // Draw layer bounds in visual coordinate space
             ctx.strokeRect(offsetX - layerWidth / 2, offsetY - layerHeight / 2, layerWidth, layerHeight);
         }
         ctx.restore();
@@ -3736,9 +3737,7 @@ function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js.
-        // We don't apply scale(1, -1) here because we want to work in +Y UP world space.
-        ctx.scale(transform.scale.x, transform.scale.y);
+        ctx.scale(transform.scale.x, -transform.scale.y);
     }
 
     ctx.strokeStyle = 'rgba(0, 255, 0, 0.8)';
@@ -3877,16 +3876,12 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
         const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
+        const localTopLeftY = - (layerOffsetY + layerHeight / 2);
+
         for (const rect of rects) {
             // rect coordinates are relative to the Tilemap center (local)
             const rectX = layerTopLeftX + rect.col * cellSize.x;
-            // In +Y UP, Row 0 is at visual top.
-            // World Top Y of map = layerHeight / 2 + layerOffsetY
-            // rectY is the bottom Y of the rectangle because strokeRect(x,y,w,h) in flipped context
-            // actually draws towards world negative Y.
-            // But we are in scale(1, 1) locally now? NO, Renderer is scale(zoom, -zoom).
-            // Actually, let's keep it simple and use world space +Y UP.
-            const rectY = (layerHeight / 2) - (rect.row + rect.height) * cellSize.y + layerOffsetY;
+            const rectY = localTopLeftY + rect.row * cellSize.y;
             const rectWidth = rect.width * cellSize.x;
             const rectHeight = rect.height * cellSize.y;
             drawColliderRect(rectX, rectY, rectWidth, rectHeight);
@@ -4026,10 +4021,11 @@ function paintTile(event) {
     const getCoordsInLayer = (l) => {
         const layerOffsetX = l.position.x * layerWidth;
         const layerOffsetY = l.position.y * layerHeight;
-        const layerTopLeftY = layerOffsetY + layerHeight / 2;
+        const lTopLeftX = layerOffsetX - layerWidth / 2;
+        const lTopLeftY = - (layerOffsetY + layerHeight / 2);
         return {
-            col: Math.floor((localMouseX - (layerOffsetX - layerWidth / 2)) / cellSize.x),
-            row: Math.floor((layerTopLeftY - localMouseY) / cellSize.y)
+            col: Math.floor((localMouseX - lTopLeftX) / cellSize.x),
+            row: Math.floor((localMouseY - lTopLeftY) / cellSize.y)
         };
     };
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2306,6 +2306,7 @@ function drawCameraGizmos(renderer, proj = null, view = null, cw = null, ch = nu
         if (!is3D) {
             ctx.translate(transform.x, transform.y);
             ctx.rotate(transform.rotation * Math.PI / 180);
+            ctx.scale(1, -1);
         }
 
         const r3d = window._Renderer3D;
@@ -2433,10 +2434,11 @@ function drawTileCursor() {
         const layerOffsetY = layer.position.y * layerHeight;
 
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = - (layerOffsetY + layerHeight / 2);
+        const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
         const col = Math.floor((localMouseX - layerTopLeftX) / cellSize.x);
-        const row = Math.floor((localMouseY - layerTopLeftY) / cellSize.y);
+        // localMouseY is world +Y UP. Row 0 is at layerTopLeftY.
+        const row = Math.floor((layerTopLeftY - localMouseY) / cellSize.y);
 
         if (col >= 0 && col < width && row >= 0 && row < height) {
             ctx.save();
@@ -2446,7 +2448,8 @@ function drawTileCursor() {
 
             const drawCursor = (c, r) => {
                 const tx = layerTopLeftX + c * cellSize.x;
-                const ty = layerTopLeftY + r * cellSize.y;
+                // In local Y-DOWN context, Row 0 is at Top Y = - (layerHeight / 2) - layerOffsetY
+                const ty = (r * cellSize.y) - (layerHeight / 2) - layerOffsetY;
                 ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
                 ctx.strokeRect(tx, ty, cellSize.x, cellSize.y);
             };
@@ -3685,8 +3688,9 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         for (const layer of tilemap.layers) {
             const offsetX = layer.position.x * layerWidth;
             const offsetY = layer.position.y * layerHeight;
-            // Draw layer bounds in visual coordinate space
-            ctx.strokeRect(offsetX - layerWidth / 2, offsetY - layerHeight / 2, layerWidth, layerHeight);
+            // Draw layer bounds in local Y-down space
+            const dy = - (layerHeight / 2) - offsetY;
+            ctx.strokeRect(offsetX - layerWidth / 2, dy, layerWidth, layerHeight);
         }
         ctx.restore();
     }
@@ -3737,6 +3741,8 @@ function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
+        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js.
+        // We un-flip it locally to draw in standard Y-down coordinates.
         ctx.scale(transform.scale.x, -transform.scale.y);
     }
 
@@ -3876,12 +3882,12 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
         const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
-        const localTopLeftY = - (layerOffsetY + layerHeight / 2);
-
         for (const rect of rects) {
             // rect coordinates are relative to the Tilemap center (local)
             const rectX = layerTopLeftX + rect.col * cellSize.x;
-            const rectY = localTopLeftY + rect.row * cellSize.y;
+            // In a locally-unflipped context (Y-Down), Row 0 is at visual Top.
+            // Local Top Y of map = - (layerHeight / 2) - layerOffsetY
+            const rectY = (rect.row * cellSize.y) - (layerHeight / 2) - layerOffsetY;
             const rectWidth = rect.width * cellSize.x;
             const rectHeight = rect.height * cellSize.y;
             drawColliderRect(rectX, rectY, rectWidth, rectHeight);
@@ -4021,11 +4027,11 @@ function paintTile(event) {
     const getCoordsInLayer = (l) => {
         const layerOffsetX = l.position.x * layerWidth;
         const layerOffsetY = l.position.y * layerHeight;
-        const lTopLeftX = layerOffsetX - layerWidth / 2;
-        const lTopLeftY = - (layerOffsetY + layerHeight / 2);
+        const layerTopLeftX = layerOffsetX - layerWidth / 2;
+        const layerTopLeftY = layerOffsetY + layerHeight / 2;
         return {
-            col: Math.floor((localMouseX - lTopLeftX) / cellSize.x),
-            row: Math.floor((localMouseY - lTopLeftY) / cellSize.y)
+            col: Math.floor((localMouseX - layerTopLeftX) / cellSize.x),
+            row: Math.floor((layerTopLeftY - localMouseY) / cellSize.y)
         };
     };
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2433,29 +2433,23 @@ function drawTileCursor() {
         const layerOffsetY = layer.position.y * layerHeight;
 
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY - layerHeight / 2;
+        const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
-        const mouseInLayerX = localMouseX - layerTopLeftX;
-        const mouseInLayerY = localMouseY - layerTopLeftY;
-
-        const col = Math.floor(mouseInLayerX / cellSize.x);
-        // row 0 is at visual top (highest Y). localMouseY increases downwards on screen but we want to map it to rows.
-        // wait, localMouseY here is world-like but flipped in Renderer.
-        // In Renderer I used dy = layerOffsetY + (y * grid.cellSize.y) - (mapTotalHeight / 2)
-        // and then drew at -dy.
-        // So worldY = - (layerOffsetY + (y * cellSize.y) - (mapTotalHeight / 2))
-        // worldY = -layerOffsetY - y * cellSize.y + mapTotalHeight / 2
-        // y * cellSize.y = mapTotalHeight / 2 - worldY - layerOffsetY
-        // y = (mapTotalHeight / 2 - worldY - layerOffsetY) / cellSize.y
-
-        // localMouseY here is screen-to-world mapped Y.
-        const row = Math.floor((layerHeight - (mouseInLayerY)) / cellSize.y);
+        const col = Math.floor((localMouseX - (layerOffsetX - layerWidth / 2)) / cellSize.x);
+        const row = Math.floor((layerTopLeftY - localMouseY) / cellSize.y);
 
         if (col >= 0 && col < width && row >= 0 && row < height) {
             ctx.save();
             ctx.translate(transform.x, transform.y);
             ctx.rotate(transform.rotation * Math.PI / 180);
             ctx.lineWidth = 2 / renderer.camera.effectiveZoom;
+
+            const drawCursor = (c, r) => {
+                const tx = layerTopLeftX + c * cellSize.x;
+                const ty = layerTopLeftY - (r + 1) * cellSize.y;
+                ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
+                ctx.strokeRect(tx, ty, cellSize.x, cellSize.y);
+            };
 
             if (activeTool === 'tile-brush' || activeTool === 'tile-rectangle-fill') {
                 ctx.strokeStyle = 'rgba(0, 255, 0, 0.8)';
@@ -2464,31 +2458,19 @@ function drawTileCursor() {
                 const selectedTiles = getSelectedTile();
                 if (selectedTiles && selectedTiles.length > 0) {
                     for (const tile of selectedTiles) {
-                        const tx = layerTopLeftX + (col + tile.offsetX) * cellSize.x;
-                const ty = layerHeight - (row + tile.offsetY + 1) * cellSize.y + layerTopLeftY;
-                        ctx.fillRect(tx, ty, cellSize.x, cellSize.y);
-                        ctx.strokeRect(tx, ty, cellSize.x, cellSize.y);
+                        drawCursor(col + tile.offsetX, row + tile.offsetY);
                     }
                 } else {
-                    const cursorX = layerTopLeftX + col * cellSize.x;
-            const cursorY = layerHeight - (row + 1) * cellSize.y + layerTopLeftY;
-                    ctx.fillRect(cursorX, cursorY, cellSize.x, cellSize.y);
-                    ctx.strokeRect(cursorX, cursorY, cellSize.x, cellSize.y);
+                    drawCursor(col, row);
                 }
             } else if (activeTool === 'tile-bucket') {
                 ctx.strokeStyle = 'rgba(100, 255, 100, 0.8)';
                 ctx.fillStyle = 'rgba(100, 255, 100, 0.2)';
-                const cursorX = layerTopLeftX + col * cellSize.x;
-                const cursorY = layerHeight - (row + 1) * cellSize.y + layerTopLeftY;
-                ctx.fillRect(cursorX, cursorY, cellSize.x, cellSize.y);
-                ctx.strokeRect(cursorX, cursorY, cellSize.x, cellSize.y);
+                drawCursor(col, row);
             } else { // eraser
                 ctx.strokeStyle = 'rgba(255, 0, 0, 0.8)';
                 ctx.fillStyle = 'rgba(255, 0, 0, 0.2)';
-                const cursorX = layerTopLeftX + col * cellSize.x;
-                const cursorY = layerHeight - (row + 1) * cellSize.y + layerTopLeftY;
-                ctx.fillRect(cursorX, cursorY, cellSize.x, cellSize.y);
-                ctx.strokeRect(cursorX, cursorY, cellSize.x, cellSize.y);
+                drawCursor(col, row);
             }
             ctx.restore();
             // Stop after finding the first layer under the cursor
@@ -3695,7 +3677,6 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         ctx.save();
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        ctx.scale(1, -1);
 
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
         ctx.lineWidth = 2 / camera.effectiveZoom;
@@ -3703,6 +3684,7 @@ function drawTilemapOutline(proj = null, view = null, cw = null, ch = null) {
         for (const layer of tilemap.layers) {
             const offsetX = layer.position.x * layerWidth;
             const offsetY = layer.position.y * layerHeight;
+            // Draw layer bounds in world +Y UP space
             ctx.strokeRect(offsetX - layerWidth / 2, offsetY - layerHeight / 2, layerWidth, layerHeight);
         }
         ctx.restore();
@@ -3754,12 +3736,8 @@ function drawTerrenoColliders(proj = null, view = null, cw = null, ch = null) {
     if (!is3D) {
         ctx.translate(transform.x, transform.y);
         ctx.rotate(transform.rotation * Math.PI / 180);
-        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js
-        // If we apply scale(1, -1) again here, we negate it.
-        // However, SceneView debug drawing usually happens outside the primary draw loop or needs consistent logic.
-        // Actually, the Renderer.js beginWorld applies scale(zoom, -zoom).
-        // If we want to draw collider RECTS that are defined in +Y UP world space,
-        // we should just use world coordinates.
+        // Gizmos are drawn in world context, which is already flipped scale(1, -1) in Renderer.js.
+        // We don't apply scale(1, -1) here because we want to work in +Y UP world space.
         ctx.scale(transform.scale.x, transform.scale.y);
     }
 
@@ -3902,7 +3880,13 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
         for (const rect of rects) {
             // rect coordinates are relative to the Tilemap center (local)
             const rectX = layerTopLeftX + rect.col * cellSize.x;
-            const rectY = layerTopLeftY - (rect.row + rect.height) * cellSize.y;
+            // In +Y UP, Row 0 is at visual top.
+            // World Top Y of map = layerHeight / 2 + layerOffsetY
+            // rectY is the bottom Y of the rectangle because strokeRect(x,y,w,h) in flipped context
+            // actually draws towards world negative Y.
+            // But we are in scale(1, 1) locally now? NO, Renderer is scale(zoom, -zoom).
+            // Actually, let's keep it simple and use world space +Y UP.
+            const rectY = (layerHeight / 2) - (rect.row + rect.height) * cellSize.y + layerOffsetY;
             const rectWidth = rect.width * cellSize.x;
             const rectHeight = rect.height * cellSize.y;
             drawColliderRect(rectX, rectY, rectWidth, rectHeight);
@@ -4006,14 +3990,9 @@ function paintTile(event) {
         let lastCoord = null;
 
         tilemap.layers.forEach(l => {
-            const lOffsetX = l.position.x * layerWidth;
-            const lOffsetY = l.position.y * layerHeight;
-            const lTopLeftX = lOffsetX - layerWidth / 2;
-            const lTopLeftY = lOffsetY - layerHeight / 2;
-            const mInLX = localMouseX - lTopLeftX;
-            const mInLY = localMouseY - lTopLeftY;
-            const c = Math.floor(mInLX / cellSize.x);
-            const r = Math.floor((layerHeight - mInLY) / cellSize.y);
+            const coords = getCoordsInLayer(l);
+            const c = coords.col;
+            const r = coords.row;
 
             if (c >= 0 && c < width && r >= 0 && r < height) {
                 const key = `${c},${r}`;
@@ -4047,11 +4026,10 @@ function paintTile(event) {
     const getCoordsInLayer = (l) => {
         const layerOffsetX = l.position.x * layerWidth;
         const layerOffsetY = l.position.y * layerHeight;
-        const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY - layerHeight / 2;
+        const layerTopLeftY = layerOffsetY + layerHeight / 2;
         return {
-            col: Math.floor((localMouseX - layerTopLeftX) / cellSize.x),
-            row: Math.floor((layerHeight - (localMouseY - layerTopLeftY)) / cellSize.y)
+            col: Math.floor((localMouseX - (layerOffsetX - layerWidth / 2)) / cellSize.x),
+            row: Math.floor((layerTopLeftY - localMouseY) / cellSize.y)
         };
     };
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -3891,12 +3891,12 @@ function drawTilemapColliders(proj = null, view = null, cw = null, ch = null) {
         const layerOffsetX = layer.position.x * layerWidth;
         const layerOffsetY = layer.position.y * layerHeight;
         const layerTopLeftX = layerOffsetX - layerWidth / 2;
-        const layerTopLeftY = layerOffsetY - layerHeight / 2;
+        const layerTopLeftY = layerOffsetY + layerHeight / 2;
 
         for (const rect of rects) {
             // rect coordinates are relative to the Tilemap center (local)
             const rectX = layerTopLeftX + rect.col * cellSize.x;
-            const rectY = layerTopLeftY + rect.row * cellSize.y;
+            const rectY = layerTopLeftY - (rect.row + rect.height) * cellSize.y;
             const rectWidth = rect.width * cellSize.x;
             const rectHeight = rect.height * cellSize.y;
             drawColliderRect(rectX, rectY, rectWidth, rectHeight);

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -4681,28 +4681,26 @@ export class TilemapCollider2D extends Leyes {
                     const [c, r] = key.split(',').map(Number);
                     const rectWidth_pixels = cellSize.x;
                     const rectHeight_pixels = cellSize.y;
-                    const rectTopLeftX = (c * cellSize.x) - (layerWidth / 2) + layerOffsetX;
-                    const rectTopLeftY = (r * cellSize.y) - (layerHeight / 2) + layerOffsetY;
+                    const rectCenterX = (c * cellSize.x) - (layerWidth / 2) + layerOffsetX + rectWidth_pixels / 2;
+                    const rectCenterY = (layerHeight / 2) - (r * cellSize.y) - (rectHeight_pixels / 2) + layerOffsetY;
 
-                    const centerX = rectTopLeftX + rectWidth_pixels / 2;
-                    const centerY = rectTopLeftY + rectHeight_pixels / 2;
                     const hw = rectWidth_pixels / 2;
                     const hh = rectHeight_pixels / 2;
 
                     let vertices = [];
-                    // TL: top-left, TR: top-right, BL: bottom-left, BR: bottom-right
-                    // slope_up (BL to TR): missing TL
-                    if (type === 'slope_up') vertices = [{x: -hw, y: hh}, {x: hw, y: -hh}, {x: hw, y: hh}];
-                    // slope_down (TL to BR): missing TR
-                    else if (type === 'slope_down') vertices = [{x: -hw, y: -hh}, {x: hw, y: hh}, {x: -hw, y: hh}];
-                    // slope_up_inv (BR to TL): missing BL (Ceiling slope up)
-                    else if (type === 'slope_up_inv') vertices = [{x: -hw, y: -hh}, {x: hw, y: -hh}, {x: hw, y: hh}];
-                    // slope_down_inv (TR to BL): missing BR (Ceiling slope down)
-                    else if (type === 'slope_down_inv') vertices = [{x: -hw, y: -hh}, {x: hw, y: -hh}, {x: -hw, y: hh}];
+                    // Standard Y-UP coordinates: -hh is Bottom, hh is Top. -hw is Left, hw is Right.
+                    // slope_up (Floor /): BL, BR, TR
+                    if (type === 'slope_up') vertices = [{x: -hw, y: -hh}, {x: hw, y: -hh}, {x: hw, y: hh}];
+                    // slope_down (Floor \): BL, BR, TL
+                    else if (type === 'slope_down') vertices = [{x: -hw, y: -hh}, {x: hw, y: -hh}, {x: -hw, y: hh}];
+                    // slope_up_inv (Ceiling \): TL, TR, BR
+                    else if (type === 'slope_up_inv') vertices = [{x: -hw, y: hh}, {x: hw, y: hh}, {x: hw, y: -hh}];
+                    // slope_down_inv (Ceiling /): TL, TR, BL
+                    else if (type === 'slope_down_inv') vertices = [{x: -hw, y: hh}, {x: hw, y: hh}, {x: -hw, y: -hh}];
 
                     if (vertices.length > 0) {
                         this.generatedPolygons.push({
-                            vertices: vertices.map(v => ({ x: v.x + centerX, y: v.y + centerY }))
+                            vertices: vertices.map(v => ({ x: v.x + rectCenterX, y: v.y + rectCenterY }))
                         });
                     }
                 }
@@ -4719,13 +4717,15 @@ export class TilemapCollider2D extends Leyes {
                     const rectWidth_pixels = rect.width * cellSize.x;
                     const rectHeight_pixels = rect.height * cellSize.y;
 
-                    // Ajuste clave: Restar la mitad de la altura total del layer para alinear con el pivote central
-                    const rectTopLeftX = (rect.col * cellSize.x) - (layerWidth / 2) + layerOffsetX;
-                    const rectTopLeftY = (rect.row * cellSize.y) - (layerHeight / 2) + layerOffsetY;
+                    // In +Y UP, Row 0 is at the top of the layer.
+                    // Visual Top Y of layer = layerHeight / 2 + layerOffsetY
+                    // Center Y = Top Y - (rect.row * cellSize.y) - (rectHeight_pixels / 2)
+                    const centerX = (rect.col * cellSize.x) - (layerWidth / 2) + layerOffsetX + rectWidth_pixels / 2;
+                    const centerY = (layerHeight / 2) - (rect.row * cellSize.y) - (rectHeight_pixels / 2) + layerOffsetY;
 
                     this.generatedColliders.push({
-                        x: rectTopLeftX + rectWidth_pixels / 2,
-                        y: rectTopLeftY + rectHeight_pixels / 2,
+                        x: centerX,
+                        y: centerY,
                         width: rectWidth_pixels,
                         height: rectHeight_pixels
                     });
@@ -5211,7 +5211,8 @@ export class TerrenoCollider2D extends Leyes {
                     const rectWidth = w * res;
                     const rectHeight = h * res;
                     const centerX = (c * res + rectWidth / 2) - (width / 2);
-                    const centerY = (r * res + rectHeight / 2) - (height / 2);
+                    // In +Y UP, row 0 is top. CenterY = (Height/2) - (r*res) - (rectHeight/2)
+                    const centerY = (height / 2) - (r * res) - (rectHeight / 2);
                     this.generatedColliders.push({ x: centerX, y: centerY, width: rectWidth, height: rectHeight });
                 }
             }
@@ -5251,9 +5252,10 @@ export class TerrenoCollider2D extends Leyes {
                         const simplified = this._ramerDouglasPeucker(contour, this._simplifyTolerance);
                         if (simplified.length > 2) {
                             // Centrar vértices respecto al terreno
+                            // In +Y UP, Pixel Y=0 is top. World Y = (Height/2) - Pixel Y
                             const centered = simplified.map(v => ({
                                 x: v.x - width / 2,
-                                y: v.y - height / 2
+                                y: (height / 2) - v.y
                             }));
 
                             // Comprobar si es una isla o un hueco

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -4721,7 +4721,7 @@ export class TilemapCollider2D extends Leyes {
                     // Visual Top Y of layer = layerHeight / 2 + layerOffsetY
                     // Center Y = Top Y - (rect.row * cellSize.y) - (rectHeight_pixels / 2)
                     const centerX = (rect.col * cellSize.x) - (layerWidth / 2) + layerOffsetX + rectWidth_pixels / 2;
-                    const centerY = (layerHeight / 2) - (rect.row * cellSize.y) - (rectHeight_pixels / 2) + layerOffsetY;
+                    const centerY = -((rect.row * cellSize.y) - (layerHeight / 2) + (rectHeight_pixels / 2)) + layerOffsetY;
 
                     this.generatedColliders.push({
                         x: centerX,

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -738,8 +738,7 @@ export class Renderer {
         this.ctx.save();
         this.ctx.translate(transform.x, transform.y);
         this.ctx.rotate(transform.rotation * Math.PI / 180);
-        // Counter-flip locally because world is scale(1, -1)
-        this.ctx.scale(transform.scale.x, -transform.scale.y);
+        this.ctx.scale(transform.scale.x, transform.scale.y);
 
         const mapTotalWidth = tilemap.width * grid.cellSize.x;
         const mapTotalHeight = tilemap.height * grid.cellSize.y;

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -666,9 +666,8 @@ export class Renderer {
             bCtx.globalCompositeOperation = 'source-over';
 
             this.ctx.globalAlpha = layer.opacity !== undefined ? layer.opacity : 1.0;
-            // Terrain buffer is generated in standard canvas Y-down.
-            // World context is scale(1, -1). By drawing at -w/2, -h/2 we center it.
-            this.ctx.drawImage(this._terrainBuffer, -w / 2, -h / 2, w, h);
+            // Use this.drawImage to handle local Y counter-flip
+            this.drawImage(this._terrainBuffer, 0, 0, w, h);
         }
         this.ctx.globalAlpha = 1.0;
 
@@ -780,12 +779,11 @@ export class Renderer {
                     // Comprobar límites: los azulejos fuera del ancho/alto del Tilemap no se dibujan
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
-                    const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
-                    // In a locally-flipped context (scale 1, -1), y=0 is the visual top.
-                    // dy is the coordinate in that flipped context.
-                    const dy = (y * grid.cellSize.y) - (mapTotalHeight / 2) - layerOffsetY;
+                    const centerX = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2) + (grid.cellSize.x / 2);
+                    const centerY = (mapTotalHeight / 2) - (y * grid.cellSize.y) - (grid.cellSize.y / 2) + layerOffsetY;
 
-                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
+                    // Use this.drawImage to handle local Y counter-flip
+                    this.drawImage(image, centerX, centerY, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -780,7 +780,9 @@ export class Renderer {
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
                     const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
-                    const dy = (y * grid.cellSize.y) - (mapTotalHeight / 2) - layerOffsetY;
+                    // In +Y UP, row 0 is top. World Y = (mapHeight/2) - (y * cellSize) - (cellSize/2) + layerOffsetY
+                    // Since drawImage draws from top-left, we use:
+                    const dy = (mapTotalHeight / 2) - (y * grid.cellSize.y) - grid.cellSize.y + layerOffsetY;
 
                     this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -632,8 +632,6 @@ export class Renderer {
 
         const w = terreno.width;
         const h = terreno.height;
-        const x = -w / 2;
-        const y = -h / 2;
 
         if (!this._terrainBuffer) {
             this._terrainBuffer = document.createElement('canvas');
@@ -668,7 +666,8 @@ export class Renderer {
             bCtx.globalCompositeOperation = 'source-over';
 
             this.ctx.globalAlpha = layer.opacity !== undefined ? layer.opacity : 1.0;
-            this.ctx.drawImage(this._terrainBuffer, x, y, w, h);
+            // Use this.drawImage to handle local Y counter-flip
+            this.drawImage(this._terrainBuffer, 0, 0, w, h);
         }
         this.ctx.globalAlpha = 1.0;
 
@@ -739,6 +738,7 @@ export class Renderer {
         this.ctx.save();
         this.ctx.translate(transform.x, transform.y);
         this.ctx.rotate(transform.rotation * Math.PI / 180);
+        // Counter-flip locally because world is scale(1, -1)
         this.ctx.scale(transform.scale.x, -transform.scale.y);
 
         const mapTotalWidth = tilemap.width * grid.cellSize.x;
@@ -779,12 +779,13 @@ export class Renderer {
                     // Comprobar límites: los azulejos fuera del ancho/alto del Tilemap no se dibujan
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
-                    const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
-                    // In +Y UP, row 0 is top. World Y = (mapHeight/2) - (y * cellSize) - (cellSize/2) + layerOffsetY
-                    // Since drawImage draws from top-left, we use:
-                    const dy = (mapTotalHeight / 2) - (y * grid.cellSize.y) - grid.cellSize.y + layerOffsetY;
+                    // In +Y UP, Row 0 is at visual top.
+                    // We calculate center coordinates in world space units relative to map center.
+                    const centerX = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2) + (grid.cellSize.x / 2);
+                    const centerY = (mapTotalHeight / 2) - (y * grid.cellSize.y) - (grid.cellSize.y / 2) + layerOffsetY;
 
-                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
+                    // Use this.drawImage to handle local Y counter-flip
+                    this.drawImage(image, centerX, centerY, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -780,10 +780,15 @@ export class Renderer {
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
                     const centerX = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2) + (grid.cellSize.x / 2);
-                    const centerY = (mapTotalHeight / 2) - (y * grid.cellSize.y) - (grid.cellSize.y / 2) + layerOffsetY;
+                    // In world space (+Y UP), Row 0 is at visual Top.
+                    // World Center Y of Map is transform.y. Map Height is mapTotalHeight.
+                    // Top Y of Map = transform.y + mapTotalHeight / 2.
+                    // Row y center world Y = (Top Y of layer) - (y * cellHeight) - (cellHeight / 2).
+                    // Top Y of layer = transform.y + mapTotalHeight / 2 + layerOffsetY.
+                    const worldCenterY = (mapTotalHeight / 2) - (y * grid.cellSize.y) - (grid.cellSize.y / 2) + layerOffsetY;
 
-                    // Use this.drawImage to handle local Y counter-flip
-                    this.drawImage(image, centerX, centerY, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
+                    // Use this.drawImage to handle local Y counter-flip and orientation correctly
+                    this.drawImage(image, centerX, worldCenterY, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -666,8 +666,9 @@ export class Renderer {
             bCtx.globalCompositeOperation = 'source-over';
 
             this.ctx.globalAlpha = layer.opacity !== undefined ? layer.opacity : 1.0;
-            // Use this.drawImage to handle local Y counter-flip
-            this.drawImage(this._terrainBuffer, 0, 0, w, h);
+            // Terrain buffer is generated in standard canvas Y-down.
+            // World context is scale(1, -1). By drawing at -w/2, -h/2 we center it.
+            this.ctx.drawImage(this._terrainBuffer, -w / 2, -h / 2, w, h);
         }
         this.ctx.globalAlpha = 1.0;
 
@@ -779,13 +780,12 @@ export class Renderer {
                     // Comprobar límites: los azulejos fuera del ancho/alto del Tilemap no se dibujan
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
-                    // In +Y UP, Row 0 is at visual top.
-                    // We calculate center coordinates in world space units relative to map center.
-                    const centerX = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2) + (grid.cellSize.x / 2);
-                    const centerY = (mapTotalHeight / 2) - (y * grid.cellSize.y) - (grid.cellSize.y / 2) + layerOffsetY;
+                    const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
+                    // In a locally-flipped context (scale 1, -1), y=0 is the visual top.
+                    // dy is the coordinate in that flipped context.
+                    const dy = (y * grid.cellSize.y) - (mapTotalHeight / 2) - layerOffsetY;
 
-                    // Use this.drawImage to handle local Y counter-flip
-                    this.drawImage(image, centerX, centerY, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
+                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }

--- a/js/engine/Renderer.js
+++ b/js/engine/Renderer.js
@@ -780,11 +780,9 @@ export class Renderer {
                     if (x < 0 || x >= tilemap.width || y < 0 || y >= tilemap.height) continue;
 
                     const dx = layerOffsetX + (x * grid.cellSize.x) - (mapTotalWidth / 2);
-                    const dy = layerOffsetY + (y * grid.cellSize.y) - (mapTotalHeight / 2);
+                    const dy = (y * grid.cellSize.y) - (mapTotalHeight / 2) - layerOffsetY;
 
-                    // row 0 is top, so we draw it at the highest world Y relative to the map
-                    // In +Y UP, higher world Y is visual top.
-                    this.ctx.drawImage(image, dx, -dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
+                    this.ctx.drawImage(image, dx, dy, grid.cellSize.x + 0.5, grid.cellSize.y + 0.5);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a critical visual bug where Tilemaps were rendered upside down after the coordinate system shift to +Y UP. It also resolves a UX issue where the editor would repeatedly ask to repair/migrate a project because the migration flag wasn't being correctly persisted to the configuration file.

Key changes:
1. **Renderer.js**: Updated `drawTilemap` to correctly map row indices to world Y coordinates. Row 0 now represents the highest world Y (visual top) of the tilemap.
2. **SceneView.js**: Adjusted `drawTilemapColliders` to match the new rendering logic, ensuring physics debug gizmos align with the visual tiles.
3. **AutoReparator.js**: Included Tilemap layer positions in the migration process, inverting their Y values to maintain spatial consistency.
4. **editor.js**: Implemented direct configuration saving upon migration success to ensure the `coordinateSystem: 'Y-UP'` flag is written to disk before the editor reloads.

---
*PR created automatically by Jules for task [8208560730799424213](https://jules.google.com/task/8208560730799424213) started by @CarleyInteractiveStudio*