### PR TITLE
Improve 3D Engine Axes, Grid Rendering and Camera Navigation

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1654,6 +1654,14 @@ public star() {
                         <input type="checkbox" id="prefs-show-orientation-gizmo" checked>
                         <label for="prefs-show-orientation-gizmo">Mostrar Gizmo de Orientación (3D)</label>
                     </div>
+                    <div class="checkbox-field">
+                        <input type="checkbox" id="prefs-invert-x-axis">
+                        <label for="prefs-invert-x-axis">Invertir Eje X de la Cámara (Mirar Izquierda/Derecha)</label>
+                    </div>
+                    <div class="checkbox-field">
+                        <input type="checkbox" id="prefs-invert-y-axis">
+                        <label for="prefs-invert-y-axis">Invertir Eje Y de la Cámara (Mirar Arriba/Abajo)</label>
+                    </div>
                     <hr>
                     <div class="checkbox-field">
                         <input type="checkbox" id="prefs-snapping-toggle">

--- a/js/carley-world/CarleyMath.js
+++ b/js/carley-world/CarleyMath.js
@@ -79,6 +79,37 @@ export const CarleyMath = {
         return out;
     },
 
+    // Crear matriz de rotación para cámara sin roll/tilt (pitch, yaw)
+    mat4RotationPitchYaw(out, degX, degY) {
+        const radX = degX * Math.PI / 180;
+        const radY = degY * Math.PI / 180;
+
+        const cx = Math.cos(radX), sx = Math.sin(radX);
+        const cy = Math.cos(radY), sy = Math.sin(radY);
+
+        out[0] = cy;
+        out[1] = -sy * sx;
+        out[2] = sy * cx;
+        out[3] = 0;
+
+        out[4] = 0;
+        out[5] = cx;
+        out[6] = sx;
+        out[7] = 0;
+
+        out[8] = -sy;
+        out[9] = -cy * sx;
+        out[10] = cy * cx;
+        out[11] = 0;
+
+        out[12] = 0;
+        out[13] = 0;
+        out[14] = 0;
+        out[15] = 1;
+
+        return out;
+    },
+
     // Crear matriz de perspectiva
     mat4Perspective(out, fov, aspect, near, far) {
         const f = 1.0 / Math.tan(fov * Math.PI / 360);

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -631,8 +631,16 @@ export class CarleyRenderer {
             const x = centerX + i * fineStep;
             const z = centerZ + i * fineStep;
 
-            gridVertices.push(centerX - N * fineStep, 0, z,   centerX + N * fineStep, 0, z);
-            gridVertices.push(x, 0, centerZ - N * fineStep,   x, 0, centerZ + N * fineStep);
+            // Evitar dibujar líneas que coinciden con el grid grueso para prevenir parpadeo (Z-fighting)
+            const isXMajor = Math.abs(x % coarseStep) < (fineStep * 0.1);
+            const isZMajor = Math.abs(z % coarseStep) < (fineStep * 0.1);
+
+            if (!isZMajor) {
+                gridVertices.push(centerX - N * fineStep, 0, z,   centerX + N * fineStep, 0, z);
+            }
+            if (!isXMajor) {
+                gridVertices.push(x, 0, centerZ - N * fineStep,   x, 0, centerZ + N * fineStep);
+            }
         }
 
         if (!this.dynamicGridBuffer) {

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -488,11 +488,21 @@ export class CarleyRenderer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.majorGridBuffer);
         this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(majorGridVertices), this.gl.STATIC_DRAW);
 
-        const axesVertices = [
-            -10000000, 0, 0,   10000000, 0, 0, // X: infinite line
-            0, -10000000, 0,   0, 10000000, 0, // Y: infinite line
-            0, 0, -10000000,   0, 0, 10000000  // Z: infinite line
-        ];
+        const axesVertices = [];
+        const ranges = [-10000000, -1000000, -100000, -10000, -1000, 1000, 10000, 100000, 1000000, 10000000];
+
+        // Eje X: 9 segmentos
+        for (let r = 0; r < ranges.length - 1; r++) {
+            axesVertices.push(ranges[r], 0, 0,   ranges[r+1], 0, 0);
+        }
+        // Eje Y: 9 segmentos
+        for (let r = 0; r < ranges.length - 1; r++) {
+            axesVertices.push(0, ranges[r], 0,   0, ranges[r+1], 0);
+        }
+        // Eje Z: 9 segmentos
+        for (let r = 0; r < ranges.length - 1; r++) {
+            axesVertices.push(0, 0, ranges[r],   0, 0, ranges[r+1]);
+        }
 
         this.axesBuffer = this.gl.createBuffer();
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.axesBuffer);
@@ -663,17 +673,17 @@ export class CarleyRenderer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.axesBuffer);
         this.gl.vertexAttribPointer(this.lineAttribs.position, 3, this.gl.FLOAT, false, 0, 0);
 
-        // Eje X (Rojo)
+        // Eje X (Rojo) - 9 segmentos (18 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 1.0, 0.2, 0.2, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 0, 2);
+        this.gl.drawArrays(this.gl.LINES, 0, 18);
 
-        // Eje Y (Verde)
+        // Eje Y (Verde) - 9 segmentos (18 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 0.2, 1.0, 0.2, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 2, 2);
+        this.gl.drawArrays(this.gl.LINES, 18, 18);
 
-        // Eje Z (Azul)
+        // Eje Z (Azul) - 9 segmentos (18 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 0.2, 0.2, 1.0, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 4, 2);
+        this.gl.drawArrays(this.gl.LINES, 36, 18);
     }
 
     renderMateria(materia, viewMatrix, projectionMatrix, lightSpaceMatrix, cameraPos, light) {

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -489,19 +489,22 @@ export class CarleyRenderer {
         this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(majorGridVertices), this.gl.STATIC_DRAW);
 
         const axesVertices = [];
-        const ranges = [-10000000, -1000000, -100000, -10000, -1000, 1000, 10000, 100000, 1000000, 10000000];
+        const ranges = [
+            -10000000, -1000000, -100000, -10000, -1000, -500, -200, -100, -50, -20, -10, -5, 0,
+            5, 10, 20, 50, 100, 200, 500, 1000, 10000, 100000, 1000000, 10000000
+        ];
 
-        // Eje X: 9 segmentos
+        // Eje X (Rojo) - 24 segmentos (48 vértices), dibujado ligeramente por encima del grid (Y = 0.01) para evitar Z-fighting
         for (let r = 0; r < ranges.length - 1; r++) {
-            axesVertices.push(ranges[r], 0, 0,   ranges[r+1], 0, 0);
+            axesVertices.push(ranges[r], 0.01, 0,   ranges[r+1], 0.01, 0);
         }
-        // Eje Y: 9 segmentos
+        // Eje Y (Verde) - 24 segmentos (48 vértices)
         for (let r = 0; r < ranges.length - 1; r++) {
-            axesVertices.push(0, ranges[r], 0,   0, ranges[r+1], 0);
+            axesVertices.push(0.01, ranges[r], 0.01,   0.01, ranges[r+1], 0.01);
         }
-        // Eje Z: 9 segmentos
+        // Eje Z (Azul) - 24 segmentos (48 vértices), dibujado a Y = 0.01
         for (let r = 0; r < ranges.length - 1; r++) {
-            axesVertices.push(0, 0, ranges[r],   0, 0, ranges[r+1]);
+            axesVertices.push(0, 0.01, ranges[r],   0, 0.01, ranges[r+1]);
         }
 
         this.axesBuffer = this.gl.createBuffer();
@@ -653,8 +656,9 @@ export class CarleyRenderer {
             const x = coarseCenterX + i * coarseStep;
             const z = coarseCenterZ + i * coarseStep;
 
-            majorGridVertices.push(coarseCenterX - M * coarseStep, 0, z,   coarseCenterX + M * coarseStep, 0, z);
-            majorGridVertices.push(x, 0, coarseCenterZ - M * coarseStep,   x, 0, coarseCenterZ + M * coarseStep);
+            // Dibujado a Y = 0.005 para evitar Z-fighting con el grid fino (Y = 0.0) y con los ejes (Y = 0.01)
+            majorGridVertices.push(coarseCenterX - M * coarseStep, 0.005, z,   coarseCenterX + M * coarseStep, 0.005, z);
+            majorGridVertices.push(x, 0.005, coarseCenterZ - M * coarseStep,   x, 0.005, coarseCenterZ + M * coarseStep);
         }
 
         if (!this.dynamicMajorGridBuffer) {
@@ -673,17 +677,17 @@ export class CarleyRenderer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.axesBuffer);
         this.gl.vertexAttribPointer(this.lineAttribs.position, 3, this.gl.FLOAT, false, 0, 0);
 
-        // Eje X (Rojo) - 9 segmentos (18 vértices)
+        // Eje X (Rojo) - 24 segmentos (48 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 1.0, 0.2, 0.2, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 0, 18);
+        this.gl.drawArrays(this.gl.LINES, 0, 48);
 
-        // Eje Y (Verde) - 9 segmentos (18 vértices)
+        // Eje Y (Verde) - 24 segmentos (48 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 0.2, 1.0, 0.2, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 18, 18);
+        this.gl.drawArrays(this.gl.LINES, 48, 48);
 
-        // Eje Z (Azul) - 9 segmentos (18 vértices)
+        // Eje Z (Azul) - 24 segmentos (48 vértices)
         this.gl.uniform4f(this.lineUniforms.color, 0.2, 0.2, 1.0, 1.0);
-        this.gl.drawArrays(this.gl.LINES, 36, 18);
+        this.gl.drawArrays(this.gl.LINES, 96, 48);
     }
 
     renderMateria(materia, viewMatrix, projectionMatrix, lightSpaceMatrix, cameraPos, light) {

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -156,7 +156,7 @@ export class CarleyRenderer {
             }
         `;
 
-        // Shader para dibujar líneas (Rejilla y Ejes) con desvanecimiento por distancia
+        // Shader para dibujar líneas (Rejilla y Ejes) con desvanecimiento por distancia (sin swizzling de atributos para máxima compatibilidad WebGL)
         const vsLineSource = `
             attribute vec4 aPosition;
             uniform mat4 uViewMatrix;
@@ -166,8 +166,13 @@ export class CarleyRenderer {
 
             void main() {
                 gl_Position = uProjectionMatrix * uViewMatrix * aPosition;
-                float dist = distance(aPosition.xz, uCameraPos.xz);
-                float maxDist = max(2000.0, uCameraPos.y * 6.0);
+                float dx = aPosition.x - uCameraPos.x;
+                float dz = aPosition.z - uCameraPos.z;
+                float dist = sqrt(dx * dx + dz * dz);
+                float maxDist = uCameraPos.y * 10.0;
+                if (maxDist < 5000.0) {
+                    maxDist = 5000.0;
+                }
                 vFade = 1.0 - clamp(dist / maxDist, 0.0, 1.0);
             }
         `;

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -156,21 +156,28 @@ export class CarleyRenderer {
             }
         `;
 
-        // Shader para dibujar líneas (Rejilla y Ejes)
+        // Shader para dibujar líneas (Rejilla y Ejes) con desvanecimiento por distancia
         const vsLineSource = `
             attribute vec4 aPosition;
             uniform mat4 uViewMatrix;
             uniform mat4 uProjectionMatrix;
+            uniform vec3 uCameraPos;
+            varying float vFade;
+
             void main() {
                 gl_Position = uProjectionMatrix * uViewMatrix * aPosition;
+                float dist = distance(aPosition.xz, uCameraPos.xz);
+                float maxDist = max(2000.0, uCameraPos.y * 6.0);
+                vFade = 1.0 - clamp(dist / maxDist, 0.0, 1.0);
             }
         `;
 
         const fsLineSource = `
             precision mediump float;
             uniform vec4 uColor;
+            varying float vFade;
             void main() {
-                gl_FragColor = uColor;
+                gl_FragColor = vec4(uColor.rgb, uColor.a * vFade);
             }
         `;
 
@@ -236,7 +243,8 @@ export class CarleyRenderer {
         this.lineUniforms = {
             viewMatrix: this.gl.getUniformLocation(this.lineProgram, 'uViewMatrix'),
             projectionMatrix: this.gl.getUniformLocation(this.lineProgram, 'uProjectionMatrix'),
-            color: this.gl.getUniformLocation(this.lineProgram, 'uColor')
+            color: this.gl.getUniformLocation(this.lineProgram, 'uColor'),
+            cameraPos: this.gl.getUniformLocation(this.lineProgram, 'uCameraPos')
         };
     }
 
@@ -586,13 +594,6 @@ export class CarleyRenderer {
     }
 
     drawGridAndAxes(viewMatrix, projectionMatrix) {
-        this.gl.useProgram(this.lineProgram);
-        this.gl.uniformMatrix4fv(this.lineUniforms.viewMatrix, false, viewMatrix);
-        this.gl.uniformMatrix4fv(this.lineUniforms.projectionMatrix, false, projectionMatrix);
-
-        this.gl.enable(this.gl.BLEND);
-        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
-
         // Obtener coordenadas de la cámara
         let camX = 0;
         let camY = 500;
@@ -603,6 +604,14 @@ export class CarleyRenderer {
             camY = Math.abs(window.currentCarleyWorld.cameraPosition.y || 0);
             camZ = window.currentCarleyWorld.cameraPosition.z || 0;
         }
+
+        this.gl.useProgram(this.lineProgram);
+        this.gl.uniformMatrix4fv(this.lineUniforms.viewMatrix, false, viewMatrix);
+        this.gl.uniformMatrix4fv(this.lineUniforms.projectionMatrix, false, projectionMatrix);
+        this.gl.uniform3f(this.lineUniforms.cameraPos, camX, camY, camZ);
+
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
 
         // Rejilla adaptativa y sin fin estilo Unity (LOD Grid scaling)
         const logY = Math.log10(Math.max(10, camY / 2));
@@ -627,13 +636,16 @@ export class CarleyRenderer {
         const centerX = Math.round(camX / fineStep) * fineStep;
         const centerZ = Math.round(camZ / fineStep) * fineStep;
 
+        const baseK_X = Math.round(centerX / fineStep);
+        const baseK_Z = Math.round(centerZ / fineStep);
+
         for (let i = -N; i <= N; i++) {
             const x = centerX + i * fineStep;
             const z = centerZ + i * fineStep;
 
             // Evitar dibujar líneas que coinciden con el grid grueso para prevenir parpadeo (Z-fighting)
-            const isXMajor = Math.abs(x % coarseStep) < (fineStep * 0.1);
-            const isZMajor = Math.abs(z % coarseStep) < (fineStep * 0.1);
+            const isXMajor = Math.abs(baseK_X + i) % 10 === 0;
+            const isZMajor = Math.abs(baseK_Z + i) % 10 === 0;
 
             if (!isZMajor) {
                 gridVertices.push(centerX - N * fineStep, 0, z,   centerX + N * fineStep, 0, z);

--- a/js/carley-world/CarleyRenderer.js
+++ b/js/carley-world/CarleyRenderer.js
@@ -489,9 +489,9 @@ export class CarleyRenderer {
         this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(majorGridVertices), this.gl.STATIC_DRAW);
 
         const axesVertices = [
-            -100000, 0, 0,   100000, 0, 0, // X: infinite line
-            0, -100000, 0,   0, 100000, 0, // Y: infinite line
-            0, 0, -100000,   0, 0, 100000  // Z: infinite line
+            -10000000, 0, 0,   10000000, 0, 0, // X: infinite line
+            0, -10000000, 0,   0, 10000000, 0, // Y: infinite line
+            0, 0, -10000000,   0, 0, 10000000  // Z: infinite line
         ];
 
         this.axesBuffer = this.gl.createBuffer();
@@ -599,12 +599,18 @@ export class CarleyRenderer {
         const fineStep = Math.pow(10, floorLog);
         const coarseStep = fineStep * 10;
 
-        // gridAlpha desvanece suavemente la cuadrícula fina mientras nos alejamos
-        const gridAlpha = Math.max(0, 1.0 - fraction);
+        // Opacidad máxima de la cuadrícula
+        const maxOpacity = 0.50;
+
+        // El grid fino se desvanece de maxOpacity a 0 según nos alejamos (fraction de 0 a 1)
+        const opacityFine = maxOpacity * (1.0 - fraction);
+
+        // El grid grueso aparece de 0 a maxOpacity según nos alejamos (fraction de 0 a 1)
+        const opacityCoarse = maxOpacity * fraction;
 
         // Generar líneas de rejilla fina centradas en la cámara (LOD fino)
         const gridVertices = [];
-        const N = 45; // Número de líneas a cada lado
+        const N = 150; // Más líneas para que se extienda sin fin y cubra todo el frustum de la cámara
         const centerX = Math.round(camX / fineStep) * fineStep;
         const centerZ = Math.round(camZ / fineStep) * fineStep;
 
@@ -622,14 +628,14 @@ export class CarleyRenderer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.dynamicGridBuffer);
         this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(gridVertices), this.gl.DYNAMIC_DRAW);
 
-        this.gl.uniform4f(this.lineUniforms.color, 0.15, 0.15, 0.18, gridAlpha * 0.45);
+        this.gl.uniform4f(this.lineUniforms.color, 0.25, 0.25, 0.28, opacityFine);
         this.gl.enableVertexAttribArray(this.lineAttribs.position);
         this.gl.vertexAttribPointer(this.lineAttribs.position, 3, this.gl.FLOAT, false, 0, 0);
         this.gl.drawArrays(this.gl.LINES, 0, gridVertices.length / 3);
 
         // Generar líneas de rejilla gruesa centradas en la cámara (LOD grueso)
         const majorGridVertices = [];
-        const M = 25;
+        const M = 150; // Más líneas para mayor alcance sin cortes
         const coarseCenterX = Math.round(camX / coarseStep) * coarseStep;
         const coarseCenterZ = Math.round(camZ / coarseStep) * coarseStep;
 
@@ -647,8 +653,8 @@ export class CarleyRenderer {
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.dynamicMajorGridBuffer);
         this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(majorGridVertices), this.gl.DYNAMIC_DRAW);
 
-        // La rejilla mayor siempre se ve nítida y perfectamente visible
-        this.gl.uniform4f(this.lineUniforms.color, 0.28, 0.28, 0.32, 0.85);
+        // La rejilla mayor también usa nuestra opacidad interpolada y fluida
+        this.gl.uniform4f(this.lineUniforms.color, 0.28, 0.28, 0.32, opacityCoarse);
         this.gl.enableVertexAttribArray(this.lineAttribs.position);
         this.gl.vertexAttribPointer(this.lineAttribs.position, 3, this.gl.FLOAT, false, 0, 0);
         this.gl.drawArrays(this.gl.LINES, 0, majorGridVertices.length / 3);

--- a/js/carley-world/CarleyWorld.js
+++ b/js/carley-world/CarleyWorld.js
@@ -148,7 +148,7 @@ export class CarleyWorld {
         // Construir matriz de proyección de la cámara principal
         const projectionMatrix = CarleyMath.mat4Identity();
         const aspect = this.canvas.width / this.canvas.height;
-        CarleyMath.mat4Perspective(projectionMatrix, 60, aspect, 0.1, 10000);
+        CarleyMath.mat4Perspective(projectionMatrix, 60, aspect, 0.1, 200000);
 
         // Dibujar Rejilla y Ejes Coordenados del Mundo 3D
         this.renderer.drawGridAndAxes(viewMatrix, projectionMatrix);

--- a/js/carley-world/CarleyWorld.js
+++ b/js/carley-world/CarleyWorld.js
@@ -131,31 +131,19 @@ export class CarleyWorld {
         // 4. Pase de Renderizado Principal
         this.renderer.clear();
 
-        // Construir matriz de vista de la cámara principal
+        // Construir matriz de vista de la cámara principal (con rotación Pitch-Yaw local sobre sí misma sin roll/tilt)
         const viewMatrix = CarleyMath.mat4Identity();
-        if (window.glMatrix) {
-            const mat4 = window.glMatrix.mat4;
-            const camWorld = mat4.create();
-            const translationMat = CarleyMath.mat4Identity();
-            const rotationMat = CarleyMath.mat4Identity();
+        const translationMat = CarleyMath.mat4Identity();
+        const rotationMat = CarleyMath.mat4Identity();
 
-            CarleyMath.mat4Translation(translationMat, this.cameraPosition);
-            CarleyMath.mat4RotationYXZ(rotationMat, this.cameraRotation.x, this.cameraRotation.y, this.cameraRotation.z);
-            CarleyMath.mat4Multiply(camWorld, translationMat, rotationMat);
-            mat4.invert(viewMatrix, camWorld);
-        } else {
-            // Fallback robusto sin glMatrix
-            const translationMat = CarleyMath.mat4Identity();
-            const rotationMat = CarleyMath.mat4Identity();
-            const invCamPos = {
-                x: -this.cameraPosition.x,
-                y: -this.cameraPosition.y,
-                z: -this.cameraPosition.z
-            };
-            CarleyMath.mat4Translation(translationMat, invCamPos);
-            CarleyMath.mat4RotationYXZ(rotationMat, -this.cameraRotation.x, -this.cameraRotation.y, -this.cameraRotation.z);
-            CarleyMath.mat4Multiply(viewMatrix, rotationMat, translationMat);
-        }
+        const invCamPos = {
+            x: -this.cameraPosition.x,
+            y: -this.cameraPosition.y,
+            z: -this.cameraPosition.z
+        };
+        CarleyMath.mat4Translation(translationMat, invCamPos);
+        CarleyMath.mat4RotationPitchYaw(rotationMat, -this.cameraRotation.x, -this.cameraRotation.y);
+        CarleyMath.mat4Multiply(viewMatrix, rotationMat, translationMat);
 
         // Construir matriz de proyección de la cámara principal
         const projectionMatrix = CarleyMath.mat4Identity();

--- a/js/carley-world/CarleyWorld.js
+++ b/js/carley-world/CarleyWorld.js
@@ -133,17 +133,27 @@ export class CarleyWorld {
 
         // Construir matriz de vista de la cámara principal
         const viewMatrix = CarleyMath.mat4Identity();
-        const translationMat = CarleyMath.mat4Identity();
-        const rotationMat = CarleyMath.mat4Identity();
-
-        const invCamPos = {
-            x: -this.cameraPosition.x,
-            y: -this.cameraPosition.y,
-            z: -this.cameraPosition.z
-        };
-        CarleyMath.mat4Translation(translationMat, invCamPos);
-        CarleyMath.mat4RotationYXZ(rotationMat, -this.cameraRotation.x, -this.cameraRotation.y, -this.cameraRotation.z);
-        CarleyMath.mat4Multiply(viewMatrix, rotationMat, translationMat);
+        if (window.glMatrix) {
+            const mat4 = window.glMatrix.mat4;
+            const q = window.glMatrix.quat.create();
+            // Euler rotation in degrees (x, y, z) for camera rotation
+            window.glMatrix.quat.fromEuler(q, this.cameraRotation.x, this.cameraRotation.y, this.cameraRotation.z);
+            const camWorld = mat4.create();
+            mat4.fromRotationTranslation(camWorld, q, [this.cameraPosition.x, this.cameraPosition.y, this.cameraPosition.z]);
+            mat4.invert(viewMatrix, camWorld);
+        } else {
+            // Fallback robusto sin glMatrix
+            const translationMat = CarleyMath.mat4Identity();
+            const rotationMat = CarleyMath.mat4Identity();
+            const invCamPos = {
+                x: -this.cameraPosition.x,
+                y: -this.cameraPosition.y,
+                z: -this.cameraPosition.z
+            };
+            CarleyMath.mat4Translation(translationMat, invCamPos);
+            CarleyMath.mat4RotationYXZ(rotationMat, -this.cameraRotation.x, -this.cameraRotation.y, -this.cameraRotation.z);
+            CarleyMath.mat4Multiply(viewMatrix, rotationMat, translationMat);
+        }
 
         // Construir matriz de proyección de la cámara principal
         const projectionMatrix = CarleyMath.mat4Identity();

--- a/js/carley-world/CarleyWorld.js
+++ b/js/carley-world/CarleyWorld.js
@@ -135,11 +135,13 @@ export class CarleyWorld {
         const viewMatrix = CarleyMath.mat4Identity();
         if (window.glMatrix) {
             const mat4 = window.glMatrix.mat4;
-            const q = window.glMatrix.quat.create();
-            // Euler rotation in degrees (x, y, z) for camera rotation
-            window.glMatrix.quat.fromEuler(q, this.cameraRotation.x, this.cameraRotation.y, this.cameraRotation.z);
             const camWorld = mat4.create();
-            mat4.fromRotationTranslation(camWorld, q, [this.cameraPosition.x, this.cameraPosition.y, this.cameraPosition.z]);
+            const translationMat = CarleyMath.mat4Identity();
+            const rotationMat = CarleyMath.mat4Identity();
+
+            CarleyMath.mat4Translation(translationMat, this.cameraPosition);
+            CarleyMath.mat4RotationYXZ(rotationMat, this.cameraRotation.x, this.cameraRotation.y, this.cameraRotation.z);
+            CarleyMath.mat4Multiply(camWorld, translationMat, rotationMat);
             mat4.invert(viewMatrix, camWorld);
         } else {
             // Fallback robusto sin glMatrix

--- a/js/editor.js
+++ b/js/editor.js
@@ -571,7 +571,8 @@ document.addEventListener('DOMContentLoaded', () => {
             'prefs-smart-reparator-toggle', 'code-creative-code-toggle',
             // Animation Skeletal Elements
             'animation-type-selector', 'animation-record-btn', 'skeletal-timeline', 'animation-time-slider', 'skeletal-tracks',
-            'scene-canvas-3d', 'game-canvas-3d', 'prefs-show-origin-axes', 'prefs-show-orientation-gizmo'
+            'scene-canvas-3d', 'game-canvas-3d', 'prefs-show-origin-axes', 'prefs-show-orientation-gizmo',
+            'prefs-invert-x-axis', 'prefs-invert-y-axis'
         ];
         ids.forEach(id => {
             const camelCaseId = id.replace(/-(\w)/g, (_, c) => c.toUpperCase());

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2108,21 +2108,14 @@ function handle3DCameraNavigation() {
         }
 
         // --- 2. FPS-Style Movement (WASD + Arrows, relative to look direction) ---
-        const pitchRad = cam.rotation.x * Math.PI / 180;
-        const yawRad = cam.rotation.y * Math.PI / 180;
+        const q = glm.quat.create();
+        glm.quat.fromEuler(q, cam.rotation.x, cam.rotation.y, cam.rotation.z || 0);
 
-        // Calculate look direction (localForward) based on precise camera orientation
-        const fx = Math.sin(yawRad) * Math.cos(pitchRad);
-        const fy = -Math.sin(pitchRad);
-        const fz = -Math.cos(yawRad) * Math.cos(pitchRad);
+        const localForward = glm.vec3.fromValues(0, 0, -1);
+        glm.vec3.transformQuat(localForward, localForward, q);
 
-        const localForward = glm.vec3.fromValues(fx, fy, fz);
-        glm.vec3.normalize(localForward, localForward);
-
-        // Calculate side direction (localRight) perpendicular to Forward and Up (0, 1, 0)
-        const localRight = glm.vec3.create();
-        glm.vec3.cross(localRight, localForward, glm.vec3.fromValues(0, 1, 0));
-        glm.vec3.normalize(localRight, localRight);
+        const localRight = glm.vec3.fromValues(1, 0, 0);
+        glm.vec3.transformQuat(localRight, localRight, q);
 
         const finalMove = glm.vec3.create();
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1,5 +1,4 @@
 import { world3DToScreen, drawLineClipped } from '../engine/MathUtils.js';
-import { CarleyMath } from '../carley-world/CarleyMath.js';
 // --- Module for Scene View Interactions and Gizmos ---
 
 import { getAbsoluteRect, getClosestAnchorPoint, getAnchorPosition } from '../engine/UITransformUtils.js';
@@ -2109,15 +2108,20 @@ function handle3DCameraNavigation() {
         }
 
         // --- 2. FPS-Style Movement (WASD + Arrows, relative to look direction) ---
-        const R = CarleyMath.mat4Identity();
-        CarleyMath.mat4RotationYXZ(R, cam.rotation.x, cam.rotation.y, cam.rotation.z || 0);
+        const pitchRad = cam.rotation.x * Math.PI / 180;
+        const yawRad = cam.rotation.y * Math.PI / 180;
 
-        // El vector localForward es la dirección negativa del tercer eje (Z) de la matriz de rotación
-        const localForward = glm.vec3.fromValues(-R[8], -R[9], -R[10]);
+        // Calculate look direction (localForward) based on precise camera orientation
+        const fx = Math.sin(yawRad) * Math.cos(pitchRad);
+        const fy = -Math.sin(pitchRad);
+        const fz = -Math.cos(yawRad) * Math.cos(pitchRad);
+
+        const localForward = glm.vec3.fromValues(fx, fy, fz);
         glm.vec3.normalize(localForward, localForward);
 
-        // El vector localRight es el primer eje (X) de la matriz de rotación
-        const localRight = glm.vec3.fromValues(R[0], R[1], R[2]);
+        // Calculate side direction (localRight) perpendicular to Forward and Up (0, 1, 0)
+        const localRight = glm.vec3.create();
+        glm.vec3.cross(localRight, localForward, glm.vec3.fromValues(0, 1, 0));
         glm.vec3.normalize(localRight, localRight);
 
         const finalMove = glm.vec3.create();

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -2098,8 +2098,12 @@ function handle3DCameraNavigation() {
         // --- 1. Rotation (Mouse Look) ---
         const delta = InputManager.getMouseDelta();
         if (Math.abs(delta.x) < 200 && Math.abs(delta.y) < 200) {
-            cam.rotation.y -= delta.x * rotSpeed;
-            cam.rotation.x -= delta.y * rotSpeed;
+            const prefs = typeof getPreferences === 'function' ? getPreferences() : {};
+            const invX = prefs.invertXAxis === true ? -1 : 1;
+            const invY = prefs.invertYAxis === true ? -1 : 1;
+
+            cam.rotation.y -= delta.x * rotSpeed * invX;
+            cam.rotation.x -= delta.y * rotSpeed * invY;
             cam.rotation.x = Math.max(-89.9, Math.min(89.9, cam.rotation.x));
         }
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1,4 +1,5 @@
 import { world3DToScreen, drawLineClipped } from '../engine/MathUtils.js';
+import { CarleyMath } from '../carley-world/CarleyMath.js';
 // --- Module for Scene View Interactions and Gizmos ---
 
 import { getAbsoluteRect, getClosestAnchorPoint, getAnchorPosition } from '../engine/UITransformUtils.js';
@@ -2108,14 +2109,16 @@ function handle3DCameraNavigation() {
         }
 
         // --- 2. FPS-Style Movement (WASD + Arrows, relative to look direction) ---
-        const q = glm.quat.create();
-        glm.quat.fromEuler(q, cam.rotation.x, cam.rotation.y, cam.rotation.z || 0);
+        const R = CarleyMath.mat4Identity();
+        CarleyMath.mat4RotationYXZ(R, cam.rotation.x, cam.rotation.y, cam.rotation.z || 0);
 
-        const localForward = glm.vec3.fromValues(0, 0, -1);
-        glm.vec3.transformQuat(localForward, localForward, q);
+        // El vector localForward es la dirección negativa del tercer eje (Z) de la matriz de rotación
+        const localForward = glm.vec3.fromValues(-R[8], -R[9], -R[10]);
+        glm.vec3.normalize(localForward, localForward);
 
-        const localRight = glm.vec3.fromValues(1, 0, 0);
-        glm.vec3.transformQuat(localRight, localRight, q);
+        // El vector localRight es el primer eje (X) de la matriz de rotación
+        const localRight = glm.vec3.fromValues(R[0], R[1], R[2]);
+        glm.vec3.normalize(localRight, localRight);
 
         const finalMove = glm.vec3.create();
 

--- a/js/editor/ui/PreferencesWindow.js
+++ b/js/editor/ui/PreferencesWindow.js
@@ -24,6 +24,8 @@ const defaultPrefs = {
     showSceneGrid: true,
     showOriginAxes: true,
     showOrientationGizmo: true,
+    invertXAxis: false,
+    invertYAxis: false,
     snapping: false,
     gridSize: 1,
     zoomSpeed: 1.1,
@@ -165,6 +167,8 @@ async function savePreferences() {
     currentPreferences.showSceneGrid = _dom.prefsShowSceneGrid.checked;
     currentPreferences.showOriginAxes = _dom.prefsShowOriginAxes.checked;
     currentPreferences.showOrientationGizmo = _dom.prefsShowOrientationGizmo.checked;
+    currentPreferences.invertXAxis = _dom.prefsInvertXAxis.checked;
+    currentPreferences.invertYAxis = _dom.prefsInvertYAxis.checked;
     currentPreferences.snapping = _dom.prefsSnappingToggle.checked;
     currentPreferences.gridSize = _dom.prefsSnappingGridSize.value;
     currentPreferences.zoomSpeed = parseFloat(_dom.prefsZoomSpeed.value) || 1.1;
@@ -241,6 +245,8 @@ function loadPreferences() {
     if (_dom.prefsShowSceneGrid) _dom.prefsShowSceneGrid.checked = currentPreferences.showSceneGrid;
     if (_dom.prefsShowOriginAxes) _dom.prefsShowOriginAxes.checked = currentPreferences.showOriginAxes;
     if (_dom.prefsShowOrientationGizmo) _dom.prefsShowOrientationGizmo.checked = currentPreferences.showOrientationGizmo !== false;
+    if (_dom.prefsInvertXAxis) _dom.prefsInvertXAxis.checked = !!currentPreferences.invertXAxis;
+    if (_dom.prefsInvertYAxis) _dom.prefsInvertYAxis.checked = !!currentPreferences.invertYAxis;
     if (_dom.prefsSnappingToggle) _dom.prefsSnappingToggle.checked = currentPreferences.snapping;
     if (_dom.prefsSnappingGridSize) _dom.prefsSnappingGridSize.value = currentPreferences.gridSize;
     if (_dom.prefsZoomSpeed) _dom.prefsZoomSpeed.value = currentPreferences.zoomSpeed;


### PR DESCRIPTION
This submission: 1. Confirms the Y-UP vertical axis coordinates. 2. Adds X/Y axis camera navigation inversion toggles to Editor Preferences. 3. Fixes high-altitude grid rendering flickering/clipping by increasing camera far plane to 200,000, increasing grid draw extents, and implementing a mathematically smooth LOD interpolation transition.

---
*PR created automatically by Jules for task [13764692177771773260](https://jules.google.com/task/13764692177771773260) started by @CarleyInteractiveStudio*