### PR TITLE
Fix character stuck crouched bug and improve animator controller endFrame defaults

### DIFF
--- a/js/editor/ui/InspectorWindow.js
+++ b/js/editor/ui/InspectorWindow.js
@@ -6620,7 +6620,7 @@ async function updateInspectorForAsset(assetName, assetPath) {
                         animationClip: "",
                         speed: 12.0,
                         startFrame: 0,
-                        endFrame: 5,
+                        endFrame: -1,
                         loop: true,
                         position: { x: 50 + Math.random() * 150, y: 50 + Math.random() * 150 }
                     });

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -4438,6 +4438,8 @@ export class LateralMovement extends Leyes {
                 grounded = true;
             }
         }
+
+        const wasGrounded = this._lastLoggedGrounded !== undefined ? this._lastLoggedGrounded : this.isGrounded;
         this.isGrounded = grounded;
 
         let moveX = 0;
@@ -4446,10 +4448,17 @@ export class LateralMovement extends Leyes {
 
         this.lastMove.x = moveX;
 
+        const wasCrouching = this._lastLoggedCrouching !== undefined ? this._lastLoggedCrouching : this.isCrouching;
         const isCrouching = this.isGrounded && input.isKeyPressed(this.downKey) && (!rb || Math.abs(rb.velocity.y) < 5.0);
         this.isCrouching = isCrouching;
         this.lastMove.y = isCrouching ? -1 : 0;
         const currentSpeed = isCrouching ? this.speed * 0.5 : this.speed;
+
+        if (this.isGrounded !== wasGrounded || this.isCrouching !== wasCrouching) {
+            console.log(`[LateralMovement DEBUG] grounded: ${wasGrounded} -> ${this.isGrounded} | crouching: ${wasCrouching} -> ${this.isCrouching} (rb.velocity.y: ${rb ? rb.velocity.y.toFixed(2) : '0.00'})`);
+            this._lastLoggedGrounded = this.isGrounded;
+            this._lastLoggedCrouching = this.isCrouching;
+        }
 
         if (this.useRigidbody) {
             if (rb) {

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -4446,7 +4446,7 @@ export class LateralMovement extends Leyes {
 
         this.lastMove.x = moveX;
 
-        const isCrouching = this.isGrounded && input.isKeyPressed(this.downKey) && (!rb || Math.abs(rb.velocity.y) < 1.0);
+        const isCrouching = this.isGrounded && input.isKeyPressed(this.downKey) && (!rb || Math.abs(rb.velocity.y) < 5.0);
         this.isCrouching = isCrouching;
         this.lastMove.y = isCrouching ? -1 : 0;
         const currentSpeed = isCrouching ? this.speed * 0.5 : this.speed;

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -2327,7 +2327,11 @@ export class Animator extends Leyes {
 
         // Trigger immediate load if needed
         if (!this.animationClip && this.animationClipPath && !this._isLoading) {
+            const desiredLoop = options.loop !== undefined ? options.loop : this.loop;
             this.loadAnimationClip(this.projectsDirHandle || window.projectsDirHandle).then(() => {
+                if (desiredLoop !== undefined) {
+                    this.loop = desiredLoop;
+                }
                 if (this.isPlaying) this.applyCurrentFrame();
             });
         } else if (this.animationClip) {
@@ -3667,8 +3671,9 @@ export class AnimatorController extends Leyes {
 
         const isGrounded = movement && movement.isActive && (movement.isGrounded !== undefined ? movement.isGrounded : true);
         const isLateral = movement instanceof LateralMovement;
-        // Intention check: is the user trying to move via Input?
-        const isIntentionalStop = movement && movement.isActive && movement.lastMove.x === 0 && (isLateral || movement.lastMove.y === 0) && isGrounded;
+        const isCrouching = movement && movement.isActive && (movement.isCrouching === true);
+        // Intention check: is the user trying to move via Input? (Crouching is an active movement state and shouldn't be counted as a stopped state)
+        const isIntentionalStop = movement && movement.isActive && movement.lastMove.x === 0 && ((isLateral && !isCrouching) || movement.lastMove.y === 0) && isGrounded;
 
         let horiz = 0, vert = 0, moving = false;
 
@@ -3994,6 +3999,17 @@ export class AnimatorController extends Leyes {
     onAnimationEnd(clipName) {
         // Handle transitions with hasExitTime
         if (!this.controller || !this.controller.transitions) return;
+
+        // Bypass transitions and safety fallback if LateralMovement is directly driving the states (Smart Mode)
+        const trackingMateria = this._resolveMateria(this.targetMateria) || this.materia;
+        if (trackingMateria) {
+            const movement = trackingMateria.getComponent(LateralMovement) || trackingMateria.getComponent(TopDownMovement);
+            const isLateral = movement instanceof LateralMovement;
+            const bypassTransitions = isLateral && movement && !movement.useCustomAnimations;
+            if (bypassTransitions) {
+                return;
+            }
+        }
 
         let transitionFound = false;
 

--- a/js/engine/Input.js
+++ b/js/engine/Input.js
@@ -251,17 +251,20 @@ class InputManager {
     static _onKeyUp(event) {
         if (event.target.matches('input, textarea, select')) return;
 
-        const isFromGameWindow = this._gameWindows.has(event.view);
-        const isGameCanvas = (this._activeCanvas && (this._activeCanvas.id === 'game-canvas' || this._activeCanvas.id === 'game-canvas-3d'));
-
-        if (this._isGameRunning && !isFromGameWindow && !isGameCanvas) return;
-
+        // For robustness and to avoid any keys getting stuck (such as the crouch key),
+        // we always register the keyup event to set key state to false,
+        // even if focus/active canvas conditions are not fully met.
         const key = event.key;
         const keysToSet = key.length === 1 ? [key.toLowerCase(), key.toUpperCase()] : [key];
         for (const k of keysToSet) {
             this._keys.set(k, false);
             this._keysUp.add(k);
         }
+
+        const isFromGameWindow = this._gameWindows.has(event.view);
+        const isGameCanvas = (this._activeCanvas && (this._activeCanvas.id === 'game-canvas' || this._activeCanvas.id === 'game-canvas-3d'));
+
+        if (this._isGameRunning && !isFromGameWindow && !isGameCanvas) return;
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where characters can get stuck in a crouched state due to missed key release events or incorrect animation bounds defaults. Key releases are now always processed immediately, and newly created states default to playing clips in their entirety.

---
*PR created automatically by Jules for task [11651976382528041891](https://jules.google.com/task/11651976382528041891) started by @CarleyInteractiveStudio*