### PR TITLE
Fix standalone build freezes and 404 animation clip errors on GitHub Pages

### DIFF
--- a/js/editor/BuildSystem.js
+++ b/js/editor/BuildSystem.js
@@ -663,7 +663,11 @@ async function addAssetsToZip(zipOrHandle, dirHandle, path, usedAssets = null, i
                     if (['cescene', 'ceanim', 'cea', 'cesprite'].includes(ext)) {
                         try {
                             const content = await file.text();
-                            assetsData[targetPath] = JSON.parse(content);
+                            const parsed = JSON.parse(content);
+                            assetsData[targetPath] = parsed;
+                            if (targetPath.startsWith('Assets/')) {
+                                assetsData[targetPath.substring(7)] = parsed;
+                            }
                         } catch (e) {
                             console.warn(`[BuildSystem] Failed to parse JSON for bundling: ${entryPath}`, e);
                         }

--- a/js/engine/AssetUtils.js
+++ b/js/engine/AssetUtils.js
@@ -53,13 +53,38 @@ export async function getURLForAssetPath(path, projectsDirHandle) {
     if (!path) return null;
 
     // --- Embedded Assets Support ---
-    if (typeof window !== 'undefined' && window.CE_Standalone_Assets_Data && window.CE_Standalone_Assets_Data[path]) {
-        const data = window.CE_Standalone_Assets_Data[path];
-        try {
-            const dataUrl = "data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(data))));
-            return dataUrl;
-        } catch (e) {
-            console.warn("[AssetUtils] Failed to create data URL for embedded asset:", path, e);
+    if (typeof window !== 'undefined' && window.CE_Standalone_Assets_Data) {
+        let embeddedData = window.CE_Standalone_Assets_Data[path];
+
+        if (!embeddedData) {
+            const cleanPath = path.startsWith('/') ? path.substring(1) : path;
+            const assetsPath = cleanPath.startsWith('Assets/') ? cleanPath : `Assets/${cleanPath}`;
+            const noAssetsPath = cleanPath.startsWith('Assets/') ? cleanPath.substring(7) : cleanPath;
+
+            embeddedData = window.CE_Standalone_Assets_Data[cleanPath] ||
+                           window.CE_Standalone_Assets_Data[assetsPath] ||
+                           window.CE_Standalone_Assets_Data[noAssetsPath];
+
+            if (!embeddedData) {
+                const lowerPath = cleanPath.toLowerCase();
+                const lowerAssets = assetsPath.toLowerCase();
+                for (const key in window.CE_Standalone_Assets_Data) {
+                    const lowerKey = key.toLowerCase();
+                    if (lowerKey === lowerPath || lowerKey === lowerAssets) {
+                        embeddedData = window.CE_Standalone_Assets_Data[key];
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (embeddedData) {
+            try {
+                const dataUrl = "data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(embeddedData))));
+                return dataUrl;
+            } catch (e) {
+                console.warn("[AssetUtils] Failed to create data URL for embedded asset:", path, e);
+            }
         }
     }
 

--- a/js/engine/Components.js
+++ b/js/engine/Components.js
@@ -1942,7 +1942,8 @@ export class SpriteRenderer extends Leyes {
             this.spriteSheet = await response.json();
 
             // Set source from the sheet and load the actual image
-            this.source = `Assets/${this.spriteSheet.sourceImage}`;
+            const srcImg = this.spriteSheet.sourceImage || '';
+            this.source = srcImg.startsWith('Assets/') ? srcImg : `Assets/${srcImg}`;
             await this.loadSprite(projectsDirHandle);
 
             // Default to the first sprite if none is selected
@@ -2184,7 +2185,8 @@ export class Animator extends Leyes {
                                     }
                                 }
                                 if (sheet && sheet.sourceImage) {
-                                    imagePath = `Assets/${sheet.sourceImage}`;
+                                    const srcImg = sheet.sourceImage;
+                                    imagePath = srcImg.startsWith('Assets/') ? srcImg : `Assets/${srcImg}`;
                                 }
                             } else {
                                 imagePath = assetPath;

--- a/js/engine/SceneManager.js
+++ b/js/engine/SceneManager.js
@@ -586,8 +586,22 @@ export function createSprite(name, imagePath) {
  */
 export async function instanciarPrefabDesdeRuta(path, x, y) {
     try {
+        const dirHandle = window.projectsDirHandle;
+        if (!dirHandle) {
+            const { getURLForAssetPath } = await import('./AssetUtils.js');
+            const url = await getURLForAssetPath(path);
+            if (!url) throw new Error(`Could not find URL for prefab: ${path}`);
+            const resp = await fetch(url);
+            const prefabData = await resp.json();
+            const newMateria = await instanciarPrefab(prefabData, x, y);
+            if (newMateria) {
+                newMateria.prefabPath = path;
+            }
+            return newMateria;
+        }
+
         const projectName = new URLSearchParams(window.location.search).get('project');
-        let currentHandle = await window.projectsDirHandle.getDirectoryHandle(projectName);
+        let currentHandle = await dirHandle.getDirectoryHandle(projectName);
         const parts = path.split('/');
         const fileName = parts.pop();
 
@@ -623,8 +637,56 @@ export const instantiatePrefabFromPath = instanciarPrefabDesdeRuta;
  */
 export async function loadSceneByPath(path) {
     try {
+        const dirHandle = window.projectsDirHandle;
+        if (!dirHandle) {
+            const { getURLForAssetPath } = await import('./AssetUtils.js');
+            let sceneUrl = await getURLForAssetPath(path);
+            if (!sceneUrl && !path.startsWith('Assets/')) {
+                sceneUrl = await getURLForAssetPath(`Assets/${path}`);
+            }
+            if (!sceneUrl) throw new Error(`Could not find URL for scene: ${path}`);
+            const resp = await fetch(sceneUrl);
+            const sceneData = await resp.json();
+            const scene = await deserializeScene(sceneData, null);
+            setCurrentScene(scene);
+
+            if (window.CE_Standalone_Runtime) {
+                const runtime = window.CE_Standalone_Runtime;
+                runtime.physicsSystem = new (await import('./Physics.js')).PhysicsSystem(scene);
+                scene.physicsSystem = runtime.physicsSystem;
+                (await import('./ui/UISystem.js')).initialize(scene);
+
+                const Components = await import('./Components.js');
+                for (const materia of scene.getAllMaterias()) {
+                    for (const ley of materia.leyes) {
+                        if (ley instanceof Components.CreativeScript) {
+                            await ley.initializeInstance();
+                            if (ley.isInitialized) {
+                                try { ley.start(); } catch(e) {}
+                                try { ley.onEnable(); } catch(e) {}
+                            }
+                        } else if (ley instanceof Components.AnimatorController) {
+                            await ley.initialize(null);
+                        } else if (ley instanceof Components.Animator) {
+                            if (!materia.getComponent(Components.AnimatorController)) {
+                                await ley.loadAnimationClip(null);
+                            }
+                        }
+
+                        if (!(ley instanceof Components.CreativeScript) && typeof ley.start === 'function') {
+                            try { await ley.start(); } catch(e) {}
+                        }
+                    }
+                }
+            } else if (window.Runtime && typeof window.Runtime.restartWithScene === 'function') {
+                window.Runtime.restartWithScene(scene);
+            }
+
+            return scene;
+        }
+
         const projectName = new URLSearchParams(window.location.search).get('project');
-        let currentHandle = await window.projectsDirHandle.getDirectoryHandle(projectName);
+        let currentHandle = await dirHandle.getDirectoryHandle(projectName);
         const parts = path.split('/');
         const fileName = parts.pop();
 
@@ -637,7 +699,7 @@ export async function loadSceneByPath(path) {
         }
 
         const fileHandle = await currentHandle.getFileHandle(fileName);
-        const result = await loadScene(fileHandle, window.projectsDirHandle);
+        const result = await loadScene(fileHandle, dirHandle);
 
         if (result) {
             setCurrentScene(result.scene);

--- a/js/engine/StandaloneRuntime.js
+++ b/js/engine/StandaloneRuntime.js
@@ -160,8 +160,11 @@ export class StandaloneRuntime {
             console.error("Failed to load scene", e);
         }
 
-        // 4. Initial Resize
+        // 4. Initial Resize & Window Resize Listener
         if (this.renderer) this.renderer.resize();
+        window.addEventListener('resize', () => {
+            if (this.renderer) this.renderer.resize();
+        });
 
         // 5. Start Loop
         this.lastTime = performance.now();
@@ -218,8 +221,6 @@ export class StandaloneRuntime {
             SceneManager.currentScene.getAllMaterias().forEach(m => {
                 if (m.isActive) m.update(this.deltaTime);
             });
-
-            this.renderer.resize();
 
             const cameras = SceneManager.currentScene.findAllCameras()
                 .sort((a, b) => a.getComponent(Components.Camera).depth - b.getComponent(Components.Camera).depth);
@@ -402,15 +403,7 @@ export class StandaloneRuntime {
                                     img.src = url;
                                 });
                             } else if (['mp3', 'wav', 'ogg'].includes(ext)) {
-                                await new Promise((res) => {
-                                    const audio = new Audio();
-                                    audio.oncanplaythrough = res;
-                                    audio.onerror = res;
-                                    audio.src = url;
-                                    audio.load();
-                                    // Fallback for some browsers that won't fire canplaythrough without user interaction
-                                    setTimeout(res, 500);
-                                });
+                                await fetch(url).catch(() => {});
                             } else {
                                 // Just fetch the file to put it in browser cache
                                 await fetch(url).catch(() => {});


### PR DESCRIPTION
Fixed standalone game builds getting stuck or failing to play character animations on web hosts like GitHub Pages.

Key fixes:
- Resolved 404 errors for animation clips (`.cea`, `.ceanim`, `.ceSprite`) on web hosts by normalizing asset key matching in `AssetUtils.getURLForAssetPath` against embedded `window.CE_Standalone_Assets_Data`.
- Fixed double-prefixing of `Assets/` in `Animator` and `SpriteRenderer` (`Components.js`).
- Fixed `loadSceneByPath` and `instanciarPrefabDesdeRuta` in `SceneManager.js` for standalone builds where `window.projectsDirHandle` is null.
- Eliminated performance slowdown in `StandaloneRuntime.js` by removing redundant per-frame `renderer.resize()` calls and attaching a window `resize` event listener.
- Made resource preloading non-blocking for audio assets to prevent startup stalls.

---
*PR created automatically by Jules for task [6578299843126257859](https://jules.google.com/task/6578299843126257859) started by @CarleyInteractiveStudio*