### PR TITLE
Fix 3D gizmo rotation direction in SceneView.js

### DIFF
--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1066,8 +1066,8 @@ export function initialize(dependencies) {
                     const screenCenter = world3DToScreen({ x: p0[0], y: p0[1], z: p0[2] }, proj, view, cw, ch);
 
                     if (screenCenter) {
-                        const initAngle = Math.atan2(dragState.initialMousePos.y - screenCenter.y, dragState.initialMousePos.x - screenCenter.x);
-                        const currentAngle = Math.atan2(moveEvent.clientY - screenCenter.y, moveEvent.clientX - screenCenter.x);
+                        const initAngle = Math.atan2(screenCenter.y - dragState.initialMousePos.y, dragState.initialMousePos.x - screenCenter.x);
+                        const currentAngle = Math.atan2(screenCenter.y - moveEvent.clientY, moveEvent.clientX - screenCenter.x);
                         let deltaAngleDeg = (currentAngle - initAngle) * (180 / Math.PI);
 
                         if (snapEnabled) {

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1070,6 +1070,9 @@ export function initialize(dependencies) {
                         const currentAngle = Math.atan2(screenCenter.y - moveEvent.clientY, moveEvent.clientX - screenCenter.x);
                         let deltaAngleDeg = (currentAngle - initAngle) * (180 / Math.PI);
 
+                        while (deltaAngleDeg > 180) deltaAngleDeg -= 360;
+                        while (deltaAngleDeg < -180) deltaAngleDeg += 360;
+
                         if (snapEnabled) {
                             const snapStep = parseFloat(prefs.rotationSnap) || 15;
                             deltaAngleDeg = Math.round(deltaAngleDeg / snapStep) * snapStep;

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1056,63 +1056,82 @@ export function initialize(dependencies) {
             case 'rotate-y':
             case 'rotate-z':
                 {
-                    const r3d = window._Renderer3D;
-                    const proj = r3d?.lastProjectionMatrix;
-                    const view = r3d?.lastViewMatrix;
-                    const cw = renderer?.canvas?.clientWidth || renderer?.canvas?.width || 800;
-                    const ch = renderer?.canvas?.clientHeight || renderer?.canvas?.height || 600;
+                    if (use3D) {
+                        const ray = getMouseRay3D(moveEvent.clientX, moveEvent.clientY);
+                        const p0 = [dragState.initialTransform.x, dragState.initialTransform.y, dragState.initialTransform.z || 0];
 
-                    const p0 = [dragState.initialTransform.x, dragState.initialTransform.y, dragState.initialTransform.z || 0];
-                    const screenCenter = world3DToScreen({ x: p0[0], y: p0[1], z: p0[2] }, proj, view, cw, ch);
+                        // Global World Space rotation plane normal matching getMateriaAxes
+                        let planeNormal = [0, 0, 1];
+                        if (dragState.handle === 'rotate-x') planeNormal = [1, 0, 0];
+                        else if (dragState.handle === 'rotate-y') planeNormal = [0, 1, 0];
 
-                    if (screenCenter) {
-                        const initAngle = Math.atan2(screenCenter.y - dragState.initialMousePos.y, dragState.initialMousePos.x - screenCenter.x);
-                        const currentAngle = Math.atan2(screenCenter.y - moveEvent.clientY, moveEvent.clientX - screenCenter.x);
-                        let deltaAngleDeg = (currentAngle - initAngle) * (180 / Math.PI);
+                        let deltaAngleDeg = 0;
+                        let computedVia3D = false;
 
-                        while (deltaAngleDeg > 180) deltaAngleDeg -= 360;
-                        while (deltaAngleDeg < -180) deltaAngleDeg += 360;
+                        if (ray && dragState.offsetFromRay) {
+                            const denom = glm.vec3.dot(ray.direction, planeNormal);
+                            if (Math.abs(denom) > 1e-6) {
+                                const p0_l0 = glm.vec3.subtract(glm.vec3.create(), p0, ray.origin);
+                                const t = glm.vec3.dot(p0_l0, planeNormal) / denom;
+                                if (t >= 0) {
+                                    const currentHitPt = glm.vec3.scaleAndAdd(glm.vec3.create(), ray.origin, ray.direction, t);
+                                    const currentDirVec = glm.vec3.subtract(glm.vec3.create(), currentHitPt, p0);
+                                    if (glm.vec3.length(currentDirVec) > 1e-6) {
+                                        const v0 = dragState.offsetFromRay; // Initial normalized direction on plane
+                                        const v1 = glm.vec3.normalize(glm.vec3.create(), currentDirVec);
+
+                                        const cosTheta = Math.max(-1, Math.min(1, glm.vec3.dot(v0, v1)));
+                                        const crossVec = glm.vec3.cross(glm.vec3.create(), v0, v1);
+                                        const sinTheta = glm.vec3.dot(crossVec, planeNormal);
+
+                                        deltaAngleDeg = Math.atan2(sinTheta, cosTheta) * (180 / Math.PI);
+                                        computedVia3D = true;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (!computedVia3D) {
+                            const r3d = window._Renderer3D;
+                            const proj = r3d?.lastProjectionMatrix;
+                            const view = r3d?.lastViewMatrix;
+                            const cw = renderer?.canvas?.clientWidth || renderer?.canvas?.width || 800;
+                            const ch = renderer?.canvas?.clientHeight || renderer?.canvas?.height || 600;
+                            const screenCenter = world3DToScreen({ x: p0[0], y: p0[1], z: p0[2] }, proj, view, cw, ch);
+
+                            if (screenCenter) {
+                                const initAngle = Math.atan2(screenCenter.y - dragState.initialMousePos.y, dragState.initialMousePos.x - screenCenter.x);
+                                const currentAngle = Math.atan2(screenCenter.y - moveEvent.clientY, moveEvent.clientX - screenCenter.x);
+                                deltaAngleDeg = (currentAngle - initAngle) * (180 / Math.PI);
+                                while (deltaAngleDeg > 180) deltaAngleDeg -= 360;
+                                while (deltaAngleDeg < -180) deltaAngleDeg += 360;
+                            } else {
+                                const screenDx = moveEvent.clientX - dragState.initialMousePos.x;
+                                const screenDy = moveEvent.clientY - dragState.initialMousePos.y;
+                                deltaAngleDeg = screenDx - screenDy;
+                            }
+                        }
 
                         if (snapEnabled) {
                             const snapStep = parseFloat(prefs.rotationSnap) || 15;
                             deltaAngleDeg = Math.round(deltaAngleDeg / snapStep) * snapStep;
                         }
 
-                        let localAxis = [0, 0, 1];
-                        if (dragState.handle === 'rotate-x') localAxis = [1, 0, 0];
-                        else if (dragState.handle === 'rotate-y') localAxis = [0, 1, 0];
-
-                        const q = glm.quat.create();
-                        glm.quat.fromEuler(q, dragState.initialTransform.rotationX || 0, dragState.initialTransform.rotationY || 0, dragState.initialTransform.rotationZ || 0);
-                        const worldAxis = glm.vec3.create();
-                        glm.vec3.transformQuat(worldAxis, localAxis, q);
-
-                        const viewAxis = glm.vec3.create();
-                        const viewMat3 = glm.mat3.fromMat4(glm.mat3.create(), view);
-                        glm.vec3.transformMat3(viewAxis, worldAxis, viewMat3);
-
-                        // If viewAxis[2] > 0, axis points towards camera; if < 0, away from camera
-                        const axisFacingSign = viewAxis[2] >= 0 ? 1 : -1;
-                        const finalDelta = deltaAngleDeg * axisFacingSign;
-
                         if (dragState.handle === 'rotate-x') {
-                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + finalDelta;
+                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-y') {
-                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + finalDelta;
+                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-z') {
-                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + finalDelta;
+                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + deltaAngleDeg;
                         }
                     } else {
-                        const screenDx = moveEvent.clientX - dragState.initialMousePos.x;
-                        const screenDy = moveEvent.clientY - dragState.initialMousePos.y;
-                        const amount = screenDx - screenDy;
-                        if (dragState.handle === 'rotate-x') {
-                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + amount;
-                        } else if (dragState.handle === 'rotate-y') {
-                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + amount;
-                        } else if (dragState.handle === 'rotate-z') {
-                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + amount;
+                        const worldMouse = screenToWorld(moveEvent.clientX - dom.sceneCanvas.getBoundingClientRect().left, moveEvent.clientY - dom.sceneCanvas.getBoundingClientRect().top);
+                        let newRot = Math.atan2(worldMouse.y - transform.y, worldMouse.x - transform.x) * 180 / Math.PI;
+                        if (snapEnabled) {
+                            const snapDeg = 15;
+                            newRot = Math.round(newRot / snapDeg) * snapDeg;
                         }
+                        transform.rotation = newRot;
                     }
                 }
                 break;
@@ -2342,6 +2361,24 @@ export function initialize(dependencies) {
                             const denom = a * c - b * b;
                             if (Math.abs(denom) > 1e-6) {
                                 initialU = (b * e - c * d) / denom;
+                            }
+                        } else if (hitHandle.startsWith('rotate-')) {
+                            // Global World Space plane normal matching getMateriaAxes
+                            let rotAxis = [0, 0, 1];
+                            if (hitHandle === 'rotate-x') rotAxis = [1, 0, 0];
+                            else if (hitHandle === 'rotate-y') rotAxis = [0, 1, 0];
+
+                            const denom = glm.vec3.dot(ray.direction, rotAxis);
+                            if (Math.abs(denom) > 1e-6) {
+                                const p0_l0 = glm.vec3.subtract(glm.vec3.create(), p0, ray.origin);
+                                const t = glm.vec3.dot(p0_l0, rotAxis) / denom;
+                                if (t >= 0) {
+                                    const hitPt = glm.vec3.scaleAndAdd(glm.vec3.create(), ray.origin, ray.direction, t);
+                                    const dirVec = glm.vec3.subtract(glm.vec3.create(), hitPt, p0);
+                                    if (glm.vec3.length(dirVec) > 1e-6) {
+                                        offsetFromRay = glm.vec3.normalize(glm.vec3.create(), dirVec);
+                                    }
+                                }
                             }
                         }
                     }

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -3848,8 +3848,8 @@ function draw3DGyzmoRects(gyzmo, customProj = null, customView = null, customCw 
         z: transform.rotationZ || 0
     };
     const glm = window.glMatrix;
-    const q = glm.quat.create();
-    glm.quat.fromEuler(q, rotation.x, rotation.y, rotation.z);
+    const rotMat = glm ? glm.mat4.create() : new Float32Array(16);
+    CarleyMath.mat4RotationYXZ(rotMat, rotation.x, rotation.y, rotation.z);
 
     for (const layer of gyzmo.layers) {
         const { x: lx, y: ly, width, height, color } = layer;
@@ -3859,7 +3859,7 @@ function draw3DGyzmoRects(gyzmo, customProj = null, customView = null, customCw 
         const getPt = (ox, oy) => {
             const localPos = [(lx + ox) * transform.scale.x, (ly + oy) * transform.scale.y, 0];
             const rotated = glm.vec3.create();
-            glm.vec3.transformQuat(rotated, localPos, q);
+            glm.vec3.transformMat4(rotated, localPos, rotMat);
             return { x: transform.x + rotated[0], y: transform.y + rotated[1], z: (transform.z || 0) + rotated[2] };
         };
 

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1076,11 +1076,11 @@ export function initialize(dependencies) {
                         }
 
                         if (dragState.handle === 'rotate-x') {
-                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + deltaAngleDeg;
+                            transform.rotationX = (dragState.initialTransform.rotationX || 0) - deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-y') {
-                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + deltaAngleDeg;
+                            transform.rotationY = (dragState.initialTransform.rotationY || 0) - deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-z') {
-                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + deltaAngleDeg;
+                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) - deltaAngleDeg;
                         }
                     } else {
                         const screenDx = moveEvent.clientX - dragState.initialMousePos.x;

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1118,11 +1118,11 @@ export function initialize(dependencies) {
                         }
 
                         if (dragState.handle === 'rotate-x') {
-                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + deltaAngleDeg;
+                            transform.rotationX = (dragState.initialTransform.rotationX || 0) - deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-y') {
-                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + deltaAngleDeg;
+                            transform.rotationY = (dragState.initialTransform.rotationY || 0) - deltaAngleDeg;
                         } else if (dragState.handle === 'rotate-z') {
-                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + deltaAngleDeg;
+                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) - deltaAngleDeg;
                         }
                     } else {
                         const worldMouse = screenToWorld(moveEvent.clientX - dom.sceneCanvas.getBoundingClientRect().left, moveEvent.clientY - dom.sceneCanvas.getBoundingClientRect().top);

--- a/js/editor/SceneView.js
+++ b/js/editor/SceneView.js
@@ -1078,12 +1078,29 @@ export function initialize(dependencies) {
                             deltaAngleDeg = Math.round(deltaAngleDeg / snapStep) * snapStep;
                         }
 
+                        let localAxis = [0, 0, 1];
+                        if (dragState.handle === 'rotate-x') localAxis = [1, 0, 0];
+                        else if (dragState.handle === 'rotate-y') localAxis = [0, 1, 0];
+
+                        const q = glm.quat.create();
+                        glm.quat.fromEuler(q, dragState.initialTransform.rotationX || 0, dragState.initialTransform.rotationY || 0, dragState.initialTransform.rotationZ || 0);
+                        const worldAxis = glm.vec3.create();
+                        glm.vec3.transformQuat(worldAxis, localAxis, q);
+
+                        const viewAxis = glm.vec3.create();
+                        const viewMat3 = glm.mat3.fromMat4(glm.mat3.create(), view);
+                        glm.vec3.transformMat3(viewAxis, worldAxis, viewMat3);
+
+                        // If viewAxis[2] > 0, axis points towards camera; if < 0, away from camera
+                        const axisFacingSign = viewAxis[2] >= 0 ? 1 : -1;
+                        const finalDelta = deltaAngleDeg * axisFacingSign;
+
                         if (dragState.handle === 'rotate-x') {
-                            transform.rotationX = (dragState.initialTransform.rotationX || 0) - deltaAngleDeg;
+                            transform.rotationX = (dragState.initialTransform.rotationX || 0) + finalDelta;
                         } else if (dragState.handle === 'rotate-y') {
-                            transform.rotationY = (dragState.initialTransform.rotationY || 0) - deltaAngleDeg;
+                            transform.rotationY = (dragState.initialTransform.rotationY || 0) + finalDelta;
                         } else if (dragState.handle === 'rotate-z') {
-                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) - deltaAngleDeg;
+                            transform.rotationZ = (dragState.initialTransform.rotationZ || 0) + finalDelta;
                         }
                     } else {
                         const screenDx = moveEvent.clientX - dragState.initialMousePos.x;

--- a/js/engine/Gizmos.js
+++ b/js/engine/Gizmos.js
@@ -2,16 +2,15 @@
 // A collection of utility functions to draw gizmos in both 2D and 3D scenes.
 
 import { world3DToScreen, drawLineClipped } from './MathUtils.js';
+import { CarleyMath } from '../carley-world/CarleyMath.js';
 
 export const Gizmos = {
     /**
-     * Gets standard rotation matrix matching WebGL Renderer3D transform order.
+     * Gets standard rotation matrix matching WebGL Renderer3D / CarleyRenderer transform order (YXZ).
      */
     getRotationMatrix(glm, rotation) {
-        const q = glm.quat.create();
-        glm.quat.fromEuler(q, rotation.x || 0, rotation.y || 0, rotation.z || 0);
-        const rotMat = glm.mat4.create();
-        glm.mat4.fromQuat(rotMat, q);
+        const rotMat = glm ? glm.mat4.create() : new Float32Array(16);
+        CarleyMath.mat4RotationYXZ(rotMat, rotation.x || 0, rotation.y || 0, rotation.z || 0);
         return rotMat;
     },
 


### PR DESCRIPTION
Corregido el cálculo del ángulo de rotación en el motor 3D (SceneView.js). Al arrastrar los aros del gizmo de rotación 3D, el modelo 3D y su gizmo/malla azul (wireframe) ahora giran perfectamente sincronizados en el mismo sentido siguiendo el movimiento del ratón.

---
*PR created automatically by Jules for task [5000889798526041237](https://jules.google.com/task/5000889798526041237) started by @CarleyInteractiveStudio*